### PR TITLE
Improvement/args

### DIFF
--- a/api/args.go
+++ b/api/args.go
@@ -73,3 +73,15 @@ func withConsumerArgs(ctx *gin.Context) (askResponse bool, askRefresh bool, writ
 	updateProducer, _ = toBool(args.UpdateProducer)
 	return askRefresh, askResponse, write, updateProducer
 }
+
+func streamArgs(ctx *gin.Context) Args {
+	var args Args
+	var aType = ArgsType
+	var aDefault = ArgsDefault
+	args.FlowNetworks, _ = toBool(ctx.DefaultQuery(aType.FlowNetworks, aDefault.FlowNetworks))
+	args.Producers, _ = toBool(ctx.DefaultQuery(aType.Producers, aDefault.Producers))
+	args.Consumers, _ = toBool(ctx.DefaultQuery(aType.Consumers, aDefault.Consumers))
+	args.CommandGroups, _ = toBool(ctx.DefaultQuery(aType.CommandGroups, aDefault.CommandGroups))
+	args.Writers, _ = toBool(ctx.DefaultQuery(aType.Writers, aDefault.Writers))
+	return args
+}

--- a/api/internalutil.go
+++ b/api/internalutil.go
@@ -37,6 +37,11 @@ type Args struct {
 	ConsumerUUID    string
 	WriterUUID      string
 	AddToParent     string
+	FlowNetworks    bool
+	Producers       bool
+	Consumers       bool
+	CommandGroups   bool
+	Writers         bool
 }
 
 var ArgsType = struct {
@@ -66,7 +71,11 @@ var ArgsType = struct {
 	ConsumerUUID    string
 	WriterUUID      string
 	AddToParent     string
-  
+	FlowNetworks    string
+	Producers       string
+	Consumers       string
+	CommandGroups   string
+	Writers         string
 }{
 	Sort:            "sort",
 	Order:           "order",
@@ -94,6 +103,11 @@ var ArgsType = struct {
 	ConsumerUUID:    "consumer_uuid",
 	WriterUUID:      "writer_uuid",
 	AddToParent:     "add_to_parent",
+	FlowNetworks:    "flow_networks",
+	Producers:       "producers",
+	Consumers:       "consumers",
+	CommandGroups:   "command_groups",
+	Writers:         "writers",
 }
 
 var ArgsDefault = struct {
@@ -121,7 +135,11 @@ var ArgsDefault = struct {
 	ConsumerUUID    string
 	WriterUUID      string
 	AddToParent     string
-
+	FlowNetworks    string
+	Producers       string
+	Consumers       string
+	CommandGroups   string
+	Writers         string
 }{
 	Sort:            "ID",
 	Order:           "DESC", //ASC or DESC
@@ -147,7 +165,11 @@ var ArgsDefault = struct {
 	ConsumerUUID:    "",
 	WriterUUID:      "",
 	AddToParent:     "",
-
+	FlowNetworks:    "false",
+	Producers:       "false",
+	Consumers:       "false",
+	CommandGroups:   "false",
+	Writers:         "false",
 }
 
 func withID(ctx *gin.Context, name string, f func(id uint)) {

--- a/api/streams.go
+++ b/api/streams.go
@@ -9,7 +9,7 @@ import (
 type StreamDatabase interface {
 	GetStreams(args Args) ([]*model.Stream, error)
 	GetStream(uuid string, args Args) (*model.Stream, error)
-	CreateStream(body *model.Stream, AddToParent string) (*model.Stream, error)
+	CreateStream(body *model.Stream) (*model.Stream, error)
 	UpdateStream(uuid string, body *model.Stream) (*model.Stream, error)
 	DeleteStream(uuid string) (bool, error)
 	DropStreams() (bool, error)
@@ -34,8 +34,7 @@ func (j *StreamAPI) GetStream(ctx *gin.Context) {
 
 func (j *StreamAPI) CreateStream(ctx *gin.Context) {
 	body, _ := getBODYStream(ctx)
-	AddToParent := parentArgs(ctx) //flowUUID
-	q, err := j.DB.CreateStream(body, AddToParent)
+	q, err := j.DB.CreateStream(body)
 	reposeHandler(q, err, ctx)
 }
 

--- a/api/streams.go
+++ b/api/streams.go
@@ -5,14 +5,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-/*
-Stream
-*/
-
 // The StreamDatabase interface for encapsulating database access.
 type StreamDatabase interface {
-	GetStream(uuid string, withChildren bool) (*model.Stream, error)
-	GetStreams(withChildren bool) ([]*model.Stream, error)
+	GetStreams(args Args) ([]*model.Stream, error)
+	GetStream(uuid string, args Args) (*model.Stream, error)
 	CreateStream(body *model.Stream, AddToParent string) (*model.Stream, error)
 	UpdateStream(uuid string, body *model.Stream) (*model.Stream, error)
 	DeleteStream(uuid string) (bool, error)
@@ -24,15 +20,15 @@ type StreamAPI struct {
 }
 
 func (j *StreamAPI) GetStreams(ctx *gin.Context) {
-	withChildren, _, _ := withChildrenArgs(ctx)
-	q, err := j.DB.GetStreams(withChildren)
+	args := streamArgs(ctx)
+	q, err := j.DB.GetStreams(args)
 	reposeHandler(q, err, ctx)
 }
 
 func (j *StreamAPI) GetStream(ctx *gin.Context) {
-	withChildren, _, _ := withChildrenArgs(ctx)
+	args := streamArgs(ctx)
 	uuid := resolveID(ctx)
-	q, err := j.DB.GetStream(uuid, withChildren)
+	q, err := j.DB.GetStream(uuid, args)
 	reposeHandler(q, err, ctx)
 }
 

--- a/database/consumer.go
+++ b/database/consumer.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"errors"
+	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/client"
 	"github.com/NubeDev/flow-framework/model"
 
@@ -24,7 +25,7 @@ func (d *GormDatabase) GetConsumers() ([]*model.Consumer, error) {
 
 // CreateConsumer make it
 func (d *GormDatabase) CreateConsumer(body *model.Consumer) (*model.Consumer, error) {
-	_, err := d.GetStream(body.StreamUUID, false)
+	_, err := d.GetStream(body.StreamUUID, api.Args{})
 	if err != nil {
 		return nil, errorMsg("GetStreamGateway", "error on trying to get validate the stream UUID", nil)
 	}

--- a/database/db.go
+++ b/database/db.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/eventbus"
 	"github.com/NubeDev/flow-framework/model"
 	"github.com/patrickmn/go-cache"
@@ -104,7 +105,7 @@ func (d *GormDatabase) DropAllFlow() (string, error) {
 //SyncTopics sync all the topics
 func (d *GormDatabase) SyncTopics() {
 
-	g, err := d.GetStreams(false)
+	g, err := d.GetStreams(api.Args{})
 	for _, obj := range g {
 		d.Bus.RegisterTopicParent(model.CommonNaming.Stream, obj.UUID)
 	}

--- a/database/eventbus.go
+++ b/database/eventbus.go
@@ -2,13 +2,14 @@ package database
 
 import (
 	"fmt"
+	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/eventbus"
 	"github.com/NubeDev/flow-framework/model"
 )
 
 func (d *GormDatabase) producerBroadcast(producer model.ProducerBody) error {
 	t := fmt.Sprintf("%s", eventbus.ProducerEvent)
-	stream, err := d.GetStream(producer.StreamUUID, false)
+	stream, err := d.GetStream(producer.StreamUUID, api.Args{})
 	if err != nil {
 		return err
 	}

--- a/database/producer.go
+++ b/database/producer.go
@@ -3,6 +3,7 @@ package database
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/eventbus"
 	"github.com/NubeDev/flow-framework/model"
 	"github.com/NubeDev/flow-framework/utils"
@@ -29,7 +30,7 @@ func (d *GormDatabase) GetProducers() ([]*model.Producer, error) {
 // CreateProducer make it
 func (d *GormDatabase) CreateProducer(body *model.Producer) (*model.Producer, error) {
 	//call points and make it exists
-	_, err := d.GetStream(body.StreamUUID, false)
+	_, err := d.GetStream(body.StreamUUID, api.Args{})
 	if err != nil {
 		return nil, errorMsg("GetStreamGateway", "error on trying to get validate the gateway UUID", nil)
 	}

--- a/database/streams.go
+++ b/database/streams.go
@@ -27,12 +27,9 @@ func (d *GormDatabase) GetStream(uuid string, args api.Args) (*model.Stream, err
 	return gatewayModel, nil
 }
 
-func (d *GormDatabase) CreateStream(body *model.Stream, AddToParent string) (*model.Stream, error) {
+func (d *GormDatabase) CreateStream(body *model.Stream) (*model.Stream, error) {
 	body.UUID = utils.MakeTopicUUID(model.CommonNaming.Stream)
 	body.Name = nameIsNil(body.Name)
-	var flowNetwork model.FlowNetwork
-	flowNetwork.UUID = AddToParent
-	body.FlowNetworks = []*model.FlowNetwork{&flowNetwork}
 	err := d.DB.Create(&body).Error
 	if err != nil {
 		return nil, errorMsg("CreateStreamGateway", "error on trying to add a new stream gateway", nil)

--- a/database/streams.go
+++ b/database/streams.go
@@ -1,30 +1,32 @@
 package database
 
 import (
+	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/model"
 	"github.com/NubeDev/flow-framework/utils"
 	"gorm.io/gorm"
 )
 
-// GetStreams get all of them
-func (d *GormDatabase) GetStreams(withChildren bool) ([]*model.Stream, error) {
+func (d *GormDatabase) GetStreams(args api.Args) ([]*model.Stream, error) {
 	var gatewaysModel []*model.Stream
-	if withChildren { // drop child to reduce json size
-		query := d.DB.Preload("FlowNetworks").Preload("Producer").Preload("Producer.WriterClone").Preload("Consumer").Preload("Consumer.Writer").Find(&gatewaysModel)
-		if query.Error != nil {
-			return nil, query.Error
-		}
-		return gatewaysModel, nil
-	} else {
-		query := d.DB.Find(&gatewaysModel)
-		if query.Error != nil {
-			return nil, query.Error
-		}
-		return gatewaysModel, nil
+	query := d.createStreamQueryWithArgs(args)
+	query.Find(&gatewaysModel)
+	if query.Error != nil {
+		return nil, query.Error
 	}
+	return gatewaysModel, nil
 }
 
-// CreateStream make it
+func (d *GormDatabase) GetStream(uuid string, args api.Args) (*model.Stream, error) {
+	var gatewayModel *model.Stream
+	query := d.createStreamQueryWithArgs(args)
+	query = query.Where("uuid = ? ", uuid).First(&gatewayModel)
+	if query.Error != nil {
+		return nil, query.Error
+	}
+	return gatewayModel, nil
+}
+
 func (d *GormDatabase) CreateStream(body *model.Stream, AddToParent string) (*model.Stream, error) {
 	body.UUID = utils.MakeTopicUUID(model.CommonNaming.Stream)
 	body.Name = nameIsNil(body.Name)
@@ -38,22 +40,47 @@ func (d *GormDatabase) CreateStream(body *model.Stream, AddToParent string) (*mo
 	return body, nil
 }
 
-// GetStream get it
-func (d *GormDatabase) GetStream(uuid string, withChildren bool) (*model.Stream, error) {
+func (d *GormDatabase) DeleteStream(uuid string) (bool, error) {
 	var gatewayModel *model.Stream
-	var query *gorm.DB = nil
-	if withChildren {
-		query = d.DB.Preload("FlowNetworks").Preload("Producer").Preload("Producer.WriterClone").Preload("Consumer").Preload("Consumer.Writer").Where("uuid = ? ", uuid).First(&gatewayModel)
-	} else {
-		query = d.DB.Where("uuid = ? ", uuid).First(&gatewayModel)
+	query := d.DB.Where("uuid = ? ", uuid).Delete(&gatewayModel)
+	if query.Error != nil {
+		return false, query.Error
 	}
+	r := query.RowsAffected
+	if r == 0 {
+		return false, nil
+	} else {
+		return true, nil
+	}
+}
+
+func (d *GormDatabase) UpdateStream(uuid string, body *model.Stream) (*model.Stream, error) {
+	var gatewayModel *model.Stream
+	query := d.DB.Where("uuid = ?", uuid).Find(&gatewayModel)
+	if query.Error != nil {
+		return nil, query.Error
+	}
+	query = d.DB.Model(&gatewayModel).Updates(body)
 	if query.Error != nil {
 		return nil, query.Error
 	}
 	return gatewayModel, nil
 }
 
-// GetFlowUUID get flowNetwork stream and flow network
+func (d *GormDatabase) DropStreams() (bool, error) {
+	var gatewayModel *model.Stream
+	query := d.DB.Where("1 = 1").Delete(&gatewayModel)
+	if query.Error != nil {
+		return false, query.Error
+	}
+	r := query.RowsAffected
+	if r == 0 {
+		return false, nil
+	} else {
+		return true, nil
+	}
+}
+
 func (d *GormDatabase) GetFlowUUID(uuid string) (*model.Stream, *model.FlowNetwork, error) {
 	var stream *model.Stream
 	query := d.DB.Preload("FlowNetworks").Where("uuid = ? ", uuid).First(&stream)
@@ -71,49 +98,25 @@ func (d *GormDatabase) GetFlowUUID(uuid string) (*model.Stream, *model.FlowNetwo
 	return stream, flow, nil
 }
 
-// DeleteStream deletes it
-func (d *GormDatabase) DeleteStream(uuid string) (bool, error) {
-	var gatewayModel *model.Stream
-	query := d.DB.Where("uuid = ? ", uuid).Delete(&gatewayModel)
-	if query.Error != nil {
-		return false, query.Error
+func (d *GormDatabase) createStreamQueryWithArgs(args api.Args) *gorm.DB {
+	query := d.DB
+	if args.FlowNetworks {
+		query = query.Preload("FlowNetworks")
 	}
-	r := query.RowsAffected
-	if r == 0 {
-		return false, nil
-	} else {
-		return true, nil
+	if args.Producers {
+		query = query.Preload("Producers")
+		if args.Writers {
+			query = query.Preload("Producers.WriterClone")
+		}
 	}
-
-}
-
-// UpdateStream  update it
-func (d *GormDatabase) UpdateStream(uuid string, body *model.Stream) (*model.Stream, error) {
-	var gatewayModel *model.Stream
-	query := d.DB.Where("uuid = ?", uuid).Find(&gatewayModel)
-	if query.Error != nil {
-		return nil, query.Error
+	if args.Consumers {
+		query = query.Preload("Consumers")
+		if args.Writers {
+			query = query.Preload("Consumers.Writer")
+		}
 	}
-	query = d.DB.Model(&gatewayModel).Updates(body)
-	if query.Error != nil {
-		return nil, query.Error
+	if args.CommandGroups {
+		query = query.Preload("CommandGroups")
 	}
-	return gatewayModel, nil
-
-}
-
-// DropStreams delete all.
-func (d *GormDatabase) DropStreams() (bool, error) {
-	var gatewayModel *model.Stream
-	query := d.DB.Where("1 = 1").Delete(&gatewayModel)
-	if query.Error != nil {
-		return false, query.Error
-	}
-	r := query.RowsAffected
-	if r == 0 {
-		return false, nil
-	} else {
-		return true, nil
-	}
-
+	return query
 }

--- a/database/wizard.go
+++ b/database/wizard.go
@@ -52,7 +52,7 @@ func (d *GormDatabase) WizardLocalPointMapping() (bool, error) {
 	// stream
 	streamModel.FlowNetworks = []*model.FlowNetwork{&flowNetwork}
 	fmt.Println(streamModel.FlowNetworks, 9898989)
-	stream, err := d.CreateStream(&streamModel, "")
+	stream, err := d.CreateStream(&streamModel)
 	log.Debug("Created Streams at Producer side: ", stream.Name)
 
 	// producer
@@ -161,7 +161,7 @@ func (d *GormDatabase) WizardRemotePointMapping() (bool, error) {
 
 	// stream
 	streamModel.FlowNetworks = []*model.FlowNetwork{&flowNetwork}
-	stream, err := d.CreateStream(&streamModel, "")
+	stream, err := d.CreateStream(&streamModel)
 	log.Debug("Created Streams at Producer side: ", stream.Name)
 
 	// producer
@@ -186,7 +186,7 @@ func (d *GormDatabase) WizardRemotePointMapping() (bool, error) {
 	// consumer stream (edge-2)
 	consumerStreamModel.IsConsumer = true
 	consumerStreamModel.FlowNetworks = []*model.FlowNetwork{&consumerFlowNetwork}
-	consumerStream, err := d.CreateStream(&consumerStreamModel, "")
+	consumerStream, err := d.CreateStream(&consumerStreamModel)
 
 	// consumer (edge-2)
 	consumerModel.StreamUUID = consumerStream.UUID
@@ -295,7 +295,7 @@ func (d *GormDatabase) Wizard2ndFlowNetwork(body *api.AddNewFlowNetwork) (bool, 
 	// consumer stream (edge-2)
 	streamModel.IsConsumer = true
 	streamModel.FlowNetworks = []*model.FlowNetwork{&flowNetwork}
-	consumerStream, err := d.CreateStream(&streamModel, "")
+	consumerStream, err := d.CreateStream(&streamModel)
 	if err != nil {
 		fmt.Println("Error on wizard CreateStream")
 		fmt.Println(err)

--- a/model/streams.go
+++ b/model/streams.go
@@ -1,19 +1,14 @@
 package model
 
-//type StreamList struct { //TODO add is in so multiple flow networks can tap into an existing stream
-//	StreamUUID      string `json:"stream_uuid" gorm:"TYPE:string REFERENCES streams;null;default:null"`
-//	FlowNetworkUUID string `json:"flow_network_uuid" gorm:"TYPE:string REFERENCES flow_network;null;default:null"`
-//}
-
 type Stream struct {
 	CommonUUID
 	CommonName
 	CommonDescription
 	IsConsumer bool `json:"is_consumer"`
 	CommonEnable
-	Producer     []Producer     `json:"producers" gorm:"constraint:OnDelete:CASCADE;"`
-	Consumer     []Consumer     `json:"consumer" gorm:"constraint:OnDelete:CASCADE;"`
-	CommandGroup []CommandGroup `json:"command_group" gorm:"constraint:OnDelete:CASCADE;"`
-	FlowNetworks []*FlowNetwork `json:"flow_networks" gorm:"many2many:flow_networks_streams;constraint:OnDelete:CASCADE"`
+	Producers     []*Producer     `json:"producers" gorm:"constraint:OnDelete:CASCADE;"`
+	Consumers     []*Consumer     `json:"consumers" gorm:"constraint:OnDelete:CASCADE;"`
+	CommandGroups []*CommandGroup `json:"command_groups" gorm:"constraint:OnDelete:CASCADE;"`
+	FlowNetworks  []*FlowNetwork  `json:"flow_networks" gorm:"many2many:flow_networks_streams;constraint:OnDelete:CASCADE"`
 	CommonCreated
 }


### PR DESCRIPTION
### Improvements

- Improvement of Args on streams API, examples:
  - `http://{{flow_ip}}:{{flow_port}}/api/streams?flow_networks=true&producers=true&consumers=true&command_groups=true&writers=true`
  - `http://{{flow_ip}}:{{flow_port}}/api/streams/str_c8b8a1055805434b?flow_networks=true&producers=true&consumers=true&command_groups=true&writers=true`

- Fix: streams and flow_networks relationship (`add_to_parent` args was using, but it needs to be on the body as below two examples)

- FlowNetwork update with streams body (similar to that above API). Example:
  - **PATCH**: http://{{flow_ip}}:{{flow_port}}/api/flow/networks/fln_7d72222d813a463c
    ```json
    {
      "flow_token": "fakeToken123",
      "flow_ip": "0.0.0.0",
      "flow_port": "1660",
      "streams": [{"uuid": "str_4e33f4dff0d24078"}, {"uuid": "str_ad033185eeee44a2"}]
    }
    ```

- Stream update with flow_networks body. Example:
  - **PATCH**: http://{{flow_ip}}:{{flow_port}}/api/streams/str_4e33f4dff0d24078 
    ```json
    {
       "is_remote": true,
       "flow_networks": [{"uuid": "fln_3996fb7b74bb421a"}, {"uuid": "fln_7d72222d813a463c"}]
    }
    ```