### PR TITLE
Add timestamp_gt arg for api/histories/producers endpoint

### DIFF
--- a/api/argsBuilder.go
+++ b/api/argsBuilder.go
@@ -181,3 +181,11 @@ func buildTagArgs(ctx *gin.Context) Args {
 	args.Consumers, _ = toBool(ctx.DefaultQuery(aType.Consumers, aDefault.Consumers))
 	return args
 }
+
+func buildProducerHistoryArgs(ctx *gin.Context) Args {
+	var args Args
+	var aType = ArgsType
+	var aDefault = ArgsDefault
+	args.TimestampGt = ctx.DefaultQuery(aType.TimestampGt,aDefault.TimestampGt)
+	return args
+}

--- a/api/argsBuilder.go
+++ b/api/argsBuilder.go
@@ -1,6 +1,8 @@
 package api
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+)
 
 //withChildrenArgs
 func streamFieldsArgs(ctx *gin.Context) (flowUUID string, streamUUID string, producerUUID string, consumerUUID string, writerUUID string) {
@@ -185,7 +187,14 @@ func buildTagArgs(ctx *gin.Context) Args {
 func buildProducerHistoryArgs(ctx *gin.Context) Args {
 	var args Args
 	var aType = ArgsType
-	var aDefault = ArgsDefault
-	args.TimestampGt = ctx.DefaultQuery(aType.TimestampGt,aDefault.TimestampGt)
+	if value, ok := ctx.GetQuery(aType.TimestampGt); ok {
+		args.TimestampGt = &value
+	}
+	if value, ok := ctx.GetQuery(aType.TimestampLt); ok {
+		args.TimestampLt = &value
+	}
+	if order, ok := ctx.GetQuery(aType.Order); ok {
+		args.Order = order
+	}
 	return args
 }

--- a/api/internalutil.go
+++ b/api/internalutil.go
@@ -55,6 +55,7 @@ type Args struct {
 	SiteId           *string
 	DeviceId         *string
 	PluginName       bool
+	TimestampGt      string
 }
 
 var ArgsType = struct {
@@ -102,6 +103,7 @@ var ArgsType = struct {
 	SiteId           string
 	DeviceId         string
 	PluginName       string
+	TimestampGt      string
 }{
 	Sort:             "sort",
 	Order:            "order",
@@ -147,6 +149,7 @@ var ArgsType = struct {
 	SiteId:           "site_id",
 	DeviceId:         "device_id",
 	PluginName:       "by_plugin_name",
+	TimestampGt:      "timestamp_gt",
 }
 
 var ArgsDefault = struct {
@@ -188,6 +191,7 @@ var ArgsDefault = struct {
 	Priority         string
 	Tags             string
 	PluginName       string
+	TimestampGt      string
 }{
 	Sort:             "ID",
 	Order:            "DESC", //ASC or DESC
@@ -227,6 +231,7 @@ var ArgsDefault = struct {
 	Priority:         "false",
 	Tags:             "false",
 	PluginName:       "false",
+	TimestampGt:      "",
 }
 
 func reposeHandler(body interface{}, err error, ctx *gin.Context) {

--- a/api/internalutil.go
+++ b/api/internalutil.go
@@ -55,7 +55,8 @@ type Args struct {
 	SiteId           *string
 	DeviceId         *string
 	PluginName       bool
-	TimestampGt      string
+	TimestampGt      *string
+	TimestampLt      *string
 }
 
 var ArgsType = struct {
@@ -104,6 +105,7 @@ var ArgsType = struct {
 	DeviceId         string
 	PluginName       string
 	TimestampGt      string
+	TimestampLt	     string
 }{
 	Sort:             "sort",
 	Order:            "order",
@@ -150,6 +152,7 @@ var ArgsType = struct {
 	DeviceId:         "device_id",
 	PluginName:       "by_plugin_name",
 	TimestampGt:      "timestamp_gt",
+	TimestampLt: 	  "timestamp_lt",
 }
 
 var ArgsDefault = struct {
@@ -191,7 +194,6 @@ var ArgsDefault = struct {
 	Priority         string
 	Tags             string
 	PluginName       string
-	TimestampGt      string
 }{
 	Sort:             "ID",
 	Order:            "DESC", //ASC or DESC
@@ -231,7 +233,6 @@ var ArgsDefault = struct {
 	Priority:         "false",
 	Tags:             "false",
 	PluginName:       "false",
-	TimestampGt:      "",
 }
 
 func reposeHandler(body interface{}, err error, ctx *gin.Context) {
@@ -361,6 +362,10 @@ func getBodyTag(ctx *gin.Context) (dto *model.Tag, err error) {
 
 func resolveID(ctx *gin.Context) string {
 	return ctx.Param("uuid")
+}
+
+func resolveProducerUUID(ctx *gin.Context) string {
+	return ctx.Param("producer_uuid")
 }
 
 func getTagParam(ctx *gin.Context) string {

--- a/api/producerhistory.go
+++ b/api/producerhistory.go
@@ -1,20 +1,19 @@
 package api
 
 import (
+	"fmt"
 	"github.com/NubeDev/flow-framework/model"
 	"github.com/gin-gonic/gin"
 )
 
 // The ProducerHistoryDatabase interface for encapsulating database access.
 type ProducerHistoryDatabase interface {
-	GetProducerHistory(uuid string) (*model.ProducerHistory, error)
-	HistoryLatestByProducerUUID(uuid string) (*model.ProducerHistory, error)
-	HistoriesAllByProducerUUID(uuid string, order string) ([]*model.ProducerHistory, int64, error)
 	GetProducerHistories(args Args) ([]*model.ProducerHistory, error)
-	CreateProducerHistory(history *model.ProducerHistory) (*model.ProducerHistory, error)
-	DeleteProducerHistory(uuid string) (bool, error)
-	DropProducerHistories() (bool, error)
+	GetProducerHistoriesByProducerUUID(pUuid string, args Args) ([]*model.ProducerHistory, int64, error)
+	GetLatestProducerHistoryByProducerUUID(pUuid string) (*model.ProducerHistory, error)
 	CreateBulkProducerHistory(history []*model.ProducerHistory) (bool, error)
+	DeleteAllProducerHistories(args Args) (bool, error)
+	DeleteProducerHistoriesByProducerUUID(pUuid string, args Args) (bool, error)
 }
 type HistoriesAPI struct {
 	DB ProducerHistoryDatabase
@@ -26,28 +25,17 @@ func (a *HistoriesAPI) GetProducerHistories(ctx *gin.Context) {
 	reposeHandler(q, err, ctx)
 }
 
-func (a *HistoriesAPI) GetProducerHistory(ctx *gin.Context) {
-	uuid := resolveID(ctx)
-	q, err := a.DB.GetProducerHistory(uuid)
+func (a *HistoriesAPI) GetProducerHistoriesByProducerUUID(ctx *gin.Context) {
+	pUuid := resolveProducerUUID(ctx)
+	args := buildProducerHistoryArgs(ctx)
+	q, _, err := a.DB.GetProducerHistoriesByProducerUUID(pUuid, args)
 	reposeHandler(q, err, ctx)
 }
 
-func (a *HistoriesAPI) HistoriesAllByProducerUUID(ctx *gin.Context) {
-	uuid := resolveID(ctx)
-	order, _ := queryFields(ctx)
-	q, _, err := a.DB.HistoriesAllByProducerUUID(uuid, order)
-	reposeHandler(q, err, ctx)
-}
-
-func (a *HistoriesAPI) HistoryLatestByProducerUUID(ctx *gin.Context) {
-	uuid := resolveID(ctx)
-	q, err := a.DB.HistoryLatestByProducerUUID(uuid)
-	reposeHandler(q, err, ctx)
-}
-
-func (a *HistoriesAPI) CreateProducerHistory(ctx *gin.Context) {
-	body, _ := getBODYHistory(ctx)
-	q, err := a.DB.CreateProducerHistory(body)
+func (a *HistoriesAPI) GetLatestProducerHistoryByProducerUUID(ctx *gin.Context) {
+	pUuid := resolveProducerUUID(ctx)
+	fmt.Println(pUuid)
+	q, err := a.DB.GetLatestProducerHistoryByProducerUUID(pUuid)
 	reposeHandler(q, err, ctx)
 }
 
@@ -57,14 +45,16 @@ func (a *HistoriesAPI) CreateBulkProducerHistory(ctx *gin.Context) {
 	reposeHandler(q, err, ctx)
 }
 
-func (a *HistoriesAPI) DeleteProducerHistory(ctx *gin.Context) {
-	uuid := resolveID(ctx)
-	q, err := a.DB.DeleteProducerHistory(uuid)
+func (a *HistoriesAPI) DeleteAllProducerHistories(ctx *gin.Context) {
+	args := buildProducerHistoryArgs(ctx)
+	q, err := a.DB.DeleteAllProducerHistories(args)
 	reposeHandler(q, err, ctx)
+
 }
 
-func (a *HistoriesAPI) DropProducerHistories(ctx *gin.Context) {
-	q, err := a.DB.DropProducerHistories()
+func (a *HistoriesAPI) DeleteProducerHistoriesByProducerUUID(ctx *gin.Context) {
+	pUuid := resolveProducerUUID(ctx)
+	args := buildProducerHistoryArgs(ctx)
+	q, err := a.DB.DeleteProducerHistoriesByProducerUUID(pUuid, args)
 	reposeHandler(q, err, ctx)
-
 }

--- a/api/producerhistory.go
+++ b/api/producerhistory.go
@@ -10,7 +10,7 @@ type ProducerHistoryDatabase interface {
 	GetProducerHistory(uuid string) (*model.ProducerHistory, error)
 	HistoryLatestByProducerUUID(uuid string) (*model.ProducerHistory, error)
 	HistoriesAllByProducerUUID(uuid string, order string) ([]*model.ProducerHistory, int64, error)
-	GetProducerHistories() ([]*model.ProducerHistory, error)
+	GetProducerHistories(args Args) ([]*model.ProducerHistory, error)
 	CreateProducerHistory(history *model.ProducerHistory) (*model.ProducerHistory, error)
 	DeleteProducerHistory(uuid string) (bool, error)
 	DropProducerHistories() (bool, error)
@@ -21,7 +21,8 @@ type HistoriesAPI struct {
 }
 
 func (a *HistoriesAPI) GetProducerHistories(ctx *gin.Context) {
-	q, err := a.DB.GetProducerHistories()
+	args := buildProducerHistoryArgs(ctx)
+	q, err := a.DB.GetProducerHistories(args)
 	reposeHandler(q, err, ctx)
 }
 

--- a/database/producer.go
+++ b/database/producer.go
@@ -115,7 +115,6 @@ type Point struct {
 // ProducerWriteHist  update it
 func (d *GormDatabase) ProducerWriteHist(uuid string, writeData datatypes.JSON) (*model.ProducerHistory, error) {
 	ph := new(model.ProducerHistory)
-	ph.UUID = utils.MakeTopicUUID(model.CommonNaming.ProducerHistory)
 	ph.ProducerUUID = uuid
 	ph.DataStore = writeData
 	ph.Timestamp = time.Now().UTC()

--- a/database/producerhist.go
+++ b/database/producerhist.go
@@ -2,15 +2,18 @@ package database
 
 import (
 	"fmt"
+	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/model"
 	"github.com/NubeDev/flow-framework/utils"
+	"strings"
 	"time"
 )
 
 // GetProducerHistories returns all histories.
-func (d *GormDatabase) GetProducerHistories() ([]*model.ProducerHistory, error) {
+func (d *GormDatabase) GetProducerHistories(args api.Args) ([]*model.ProducerHistory, error) {
 	var historiesModel []*model.ProducerHistory
-	query := d.DB.Find(&historiesModel)
+	query := d.buildProducerHistoryQuery(args)
+	query.Find(&historiesModel)
 	if query.Error != nil {
 		return nil, query.Error
 	}
@@ -44,14 +47,11 @@ func (d *GormDatabase) HistoryLatestByProducerUUID(uuid string) (*model.Producer
 func (d *GormDatabase) HistoriesAllByProducerUUID(uuid string, order string) ([]*model.ProducerHistory, int64, error) {
 	var count int64
 	var historiesModel []*model.ProducerHistory
-	t := "DESC"
-	switch order {
-	case "ASC":
-		t = "ASC"
-	case "DESC":
-		t = "DESC"
+	order = strings.ToUpper(strings.TrimSpace(order))
+	if order != "ASC" && order != "DESC" {
+		order = "DESC"
 	}
-	t = fmt.Sprintf("timestamp %s", t)
+	t := fmt.Sprintf("timestamp %s", order)
 	q := d.DB.Where("producer_uuid = ? ", uuid).Order(t).Find(&historiesModel) //ASC or DESC
 	q.Count(&count)
 	return historiesModel, count, nil

--- a/database/queryBuilder.go
+++ b/database/queryBuilder.go
@@ -3,6 +3,7 @@ package database
 import (
 	"github.com/NubeDev/flow-framework/api"
 	"gorm.io/gorm"
+	"strings"
 )
 
 func (d *GormDatabase) buildFlowNetworkQuery(args api.Args) *gorm.DB {
@@ -135,6 +136,26 @@ func (d *GormDatabase) buildTagQuery(args api.Args) *gorm.DB {
 	if args.Networks {
 		query = query.Preload("Networks")
 	}
+	if args.Devices {
+		query = query.Preload("Devices")
+	}
+	if args.Points {
+		query = query.Preload("Points")
+	}
+	if args.Streams {
+		query = query.Preload("Streams")
+	}
+	if args.Producers {
+		query = query.Preload("Producers")
+	}
+	if args.Consumers {
+		query = query.Preload("Consumers")
+	}
+	return query
+}
+
+func (d *GormDatabase) buildTagQuery(args api.Args) *gorm.DB {
+	query := d.DB
 	if args.Devices {
 		query = query.Preload("Devices")
 	}

--- a/database/queryBuilder.go
+++ b/database/queryBuilder.go
@@ -152,3 +152,21 @@ func (d *GormDatabase) buildTagQuery(args api.Args) *gorm.DB {
 	}
 	return query
 }
+
+func (d *GormDatabase) buildProducerHistoryQuery(args api.Args) *gorm.DB {
+	query := d.DB
+	if args.TimestampGt != nil {
+		query = query.Where("timestamp > datetime(?)", args.TimestampGt)
+	}
+	if args.TimestampLt != nil {
+		query = query.Where("timestamp < datetime(?)", args.TimestampLt)
+	}
+	if args.Order != "" {
+		order := strings.ToUpper(strings.TrimSpace(args.Order))
+		if order != "ASC" && order != "DESC" {
+			args.Order = "DESC"
+		}
+		query = query.Order("timestamp " + args.Order)
+	}
+	return query
+}

--- a/database/queryBuilder.go
+++ b/database/queryBuilder.go
@@ -154,26 +154,6 @@ func (d *GormDatabase) buildTagQuery(args api.Args) *gorm.DB {
 	return query
 }
 
-func (d *GormDatabase) buildTagQuery(args api.Args) *gorm.DB {
-	query := d.DB
-	if args.Devices {
-		query = query.Preload("Devices")
-	}
-	if args.Points {
-		query = query.Preload("Points")
-	}
-	if args.Streams {
-		query = query.Preload("Streams")
-	}
-	if args.Producers {
-		query = query.Preload("Producers")
-	}
-	if args.Consumers {
-		query = query.Preload("Consumers")
-	}
-	return query
-}
-
 func (d *GormDatabase) buildProducerHistoryQuery(args api.Args) *gorm.DB {
 	query := d.DB
 	if args.TimestampGt != nil {

--- a/database/writers.go
+++ b/database/writers.go
@@ -260,7 +260,7 @@ func (d *GormDatabase) WriterAction(uuid string, body *model.WriterBody) (*model
 				return nil, errors.New("WRITER-LOCAL: error on local WRITE to writer-clone")
 			}
 		} else {
-			producerHistory, err = d.HistoryLatestByProducerUUID(producerUUID)
+			producerHistory, err = d.GetLatestProducerHistoryByProducerUUID(producerUUID)
 			if err != nil {
 				return nil, errors.New("WRITER-LOCAL: error on local READ to producer history")
 			}

--- a/model/producerhist.go
+++ b/model/producerhist.go
@@ -7,7 +7,7 @@ import (
 
 //ProducerHistory for storing the history
 type ProducerHistory struct {
-	CommonUUID
+	ID           int    `json:"id" gorm:"AUTO_INCREMENT;primary_key;index"`
 	ProducerUUID string `json:"producer_uuid" gorm:"TYPE:varchar(255) REFERENCES producers;not null;default:null"`
 	CommonCurrentProducer
 	DataStore  datatypes.JSON `json:"data_store"`

--- a/router/router.go
+++ b/router/router.go
@@ -218,12 +218,11 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 		historyProducerRoutes := apiRoutes.Group("/histories/producers")
 		{
 			historyProducerRoutes.GET("", historyHandler.GetProducerHistories)
-			historyProducerRoutes.DELETE("/drop", historyHandler.DropProducerHistories)
-			historyProducerRoutes.GET("/:uuid", historyHandler.GetProducerHistory)
-			historyProducerRoutes.GET("/latest/:uuid", historyHandler.HistoryLatestByProducerUUID) //gets the newest
-			historyProducerRoutes.GET("/all/:uuid", historyHandler.HistoriesAllByProducerUUID)
+			historyProducerRoutes.GET("/:producer_uuid", historyHandler.GetProducerHistoriesByProducerUUID)
+			historyProducerRoutes.GET("/:producer_uuid/one", historyHandler.GetLatestProducerHistoryByProducerUUID)
 			historyProducerRoutes.POST("/bulk", historyHandler.CreateBulkProducerHistory)
-			historyProducerRoutes.DELETE("/:uuid", historyHandler.DeleteProducerHistory)
+			historyProducerRoutes.DELETE("/all", historyHandler.DeleteAllProducerHistories)
+			historyProducerRoutes.DELETE("/:producer_uuid", historyHandler.DeleteProducerHistoriesByProducerUUID)
 		}
 
 		flowNetworkRoutes := apiRoutes.Group("/flow/networks")


### PR DESCRIPTION
### Summary
- Modified `histories/producers` endpoints and Added `timestamp_gt`,`timestamp_lt` and `order` optional Query Params. 
  - `timestamp_gt` and `timestamp_lt` = **YYYY-MM-DD HH-MM-SS**
  - `order` = **ASC / DESC**
- GET `/histories/producers`
  - GET `/histories/producers?timestamp_gt=<timestamp_gt>&timestamp_lt=<timestamp_lt>&order=<order>`
- GET `/histories/producers/:producer_uuid`
  - GET `/histories/producers/:producer_uuid?timestamp_gt=<timestamp_gt>&timestamp_lt=<timestamp_lt>&order=<order>`
- GET `histories/producers/:producer_uuid/one`
- POST `/histories/producers/bulk`
- DELETE `/histories/producers/all`
  - DELETE `/histories/producers/all?timestamp_gt=<timestamp_gt>&timestamp_lt=<timestamp_lt>`
- DELETE `/histories/producers/:producer_uuid`
  - DELETE `/histories/producers/:producer_uuid?timestamp_gt=<timestamp_gt>&timestamp_lt=<timestamp_lt>`
  