### PR TITLE
Improvement/resty query

### DIFF
--- a/api/internalUtils.go
+++ b/api/internalUtils.go
@@ -300,6 +300,11 @@ func getBODYFlowNetwork(ctx *gin.Context) (dto *model.FlowNetwork, err error) {
 	return dto, err
 }
 
+func getMapBody(ctx *gin.Context) (dto *map[string]interface{}, err error) {
+	err = ctx.ShouldBindJSON(&dto)
+	return dto, err
+}
+
 func getBODYNetwork(ctx *gin.Context) (dto *model.Network, err error) {
 	err = ctx.ShouldBindJSON(&dto)
 	return dto, err

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"encoding/json"
+	"github.com/NubeDev/flow-framework/model"
+	"github.com/NubeDev/flow-framework/src/client"
+	"github.com/gin-gonic/gin"
+	"strings"
+)
+
+type ProxyDatabase interface {
+	GetFN(uuid string) (*model.FlowNetwork, error)
+}
+
+type Proxy struct {
+	DB ProxyDatabase
+}
+
+func (a *Proxy) GetProxy() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		fnUUID, url := getUrl(ctx)
+		fn, err := a.DB.GetFN(fnUUID)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		cli := client.NewFlowClientCli(fn.FlowIP, fn.FlowPort, fn.FlowToken, fn.IsMasterSlave, fn.GlobalUUID, model.IsFNCreator(fn))
+
+		val, err := cli.GetQuery(url)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		response(ctx, val)
+	}
+}
+
+func (a *Proxy) PostProxy() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		fnUUID, url := getUrl(ctx)
+		fn, err := a.DB.GetFN(fnUUID)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		cli := client.NewFlowClientCli(fn.FlowIP, fn.FlowPort, fn.FlowToken, fn.IsMasterSlave, fn.GlobalUUID, model.IsFNCreator(fn))
+
+		body, err := getMapBody(ctx)
+		val, err := cli.PostQuery(url, body)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		response(ctx, val)
+	}
+}
+
+func (a *Proxy) PutProxy() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		fnUUID, url := getUrl(ctx)
+		fn, err := a.DB.GetFN(fnUUID)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		cli := client.NewFlowClientCli(fn.FlowIP, fn.FlowPort, fn.FlowToken, fn.IsMasterSlave, fn.GlobalUUID, model.IsFNCreator(fn))
+
+		body, err := getMapBody(ctx)
+		val, err := cli.PutQuery(url, body)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		response(ctx, val)
+	}
+}
+
+func (a *Proxy) PatchProxy() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		fnUUID, url := getUrl(ctx)
+		fn, err := a.DB.GetFN(fnUUID)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		cli := client.NewFlowClientCli(fn.FlowIP, fn.FlowPort, fn.FlowToken, fn.IsMasterSlave, fn.GlobalUUID, model.IsFNCreator(fn))
+
+		body, err := getMapBody(ctx)
+		val, err := cli.PatchQuery(url, body)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		response(ctx, val)
+	}
+}
+
+func (a *Proxy) DeleteProxy() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		fnUUID, url := getUrl(ctx)
+		fn, err := a.DB.GetFN(fnUUID)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		cli := client.NewFlowClientCli(fn.FlowIP, fn.FlowPort, fn.FlowToken, fn.IsMasterSlave, fn.GlobalUUID, model.IsFNCreator(fn))
+
+		err = cli.DeleteQuery(url)
+		if err != nil {
+			ctx.AbortWithError(404, err)
+			return
+		}
+		ctx.JSON(204, nil)
+	}
+}
+
+func getUrl(ctx *gin.Context) (string, string) {
+	path := ctx.Request.URL.String()
+	subStrings := strings.Split(path, "/")
+	fnUUID := subStrings[3]
+	url := ""
+	for i := 4; i < len(subStrings); i++ {
+		url += "/" + subStrings[i]
+	}
+	return fnUUID, url
+}
+
+func response(ctx *gin.Context, val *[]byte) {
+	if (*val)[0] == '{' {
+		var output map[string]interface{}
+		_ = json.Unmarshal(*val, &output)
+		ctx.JSON(200, output)
+	} else {
+		var output []interface{}
+		_ = json.Unmarshal(*val, &output)
+		ctx.JSON(200, output)
+	}
+}

--- a/database/consumer.go
+++ b/database/consumer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/model"
 	"github.com/NubeDev/flow-framework/src/client"
+	"github.com/NubeDev/flow-framework/urls"
 	"github.com/NubeDev/flow-framework/utils"
 )
 
@@ -41,10 +42,14 @@ func (d *GormDatabase) CreateConsumer(body *model.Consumer) (*model.Consumer, er
 		return nil, newError("GetOneFlowNetworkCloneByArgs", "error on trying to get validate flow_network_clone from stream_clone_uuid")
 	}
 	cli := client.NewFlowClientCli(fnc.FlowIP, fnc.FlowPort, fnc.FlowToken, fnc.IsMasterSlave, fnc.GlobalUUID, model.IsFNCreator(fnc))
-	producer, err := cli.GetProducer(body.ProducerUUID)
+	rawProducer, err := cli.GetQueryMarshal(
+		urls.ProducerSingularURL(body.ProducerUUID),
+		nil,
+		model.Producer{})
 	if err != nil {
-		return nil, newError("GetProducer", "error on finding producer by producer_uuid")
+		return nil, err
 	}
+	producer := rawProducer.(*model.Producer)
 	if streamClone.SourceUUID != producer.StreamUUID {
 		return nil, newError("Validation failure", "consumer stream_clones & producer stream are different source of truth")
 	}

--- a/database/consumer.go
+++ b/database/consumer.go
@@ -42,10 +42,7 @@ func (d *GormDatabase) CreateConsumer(body *model.Consumer) (*model.Consumer, er
 		return nil, newError("GetOneFlowNetworkCloneByArgs", "error on trying to get validate flow_network_clone from stream_clone_uuid")
 	}
 	cli := client.NewFlowClientCli(fnc.FlowIP, fnc.FlowPort, fnc.FlowToken, fnc.IsMasterSlave, fnc.GlobalUUID, model.IsFNCreator(fnc))
-	rawProducer, err := cli.GetQueryMarshal(
-		urls.ProducerSingularURL(body.ProducerUUID),
-		nil,
-		model.Producer{})
+	rawProducer, err := cli.GetQueryMarshal(urls.ProducerSingularURL(body.ProducerUUID), model.Producer{})
 	if err != nil {
 		return nil, err
 	}

--- a/database/proxy.go
+++ b/database/proxy.go
@@ -1,0 +1,13 @@
+package database
+
+import (
+	"github.com/NubeDev/flow-framework/model"
+)
+
+func (d *GormDatabase) GetFN(uuid string) (*model.FlowNetwork, error) {
+	var flowNetworkModel *model.FlowNetwork
+	if err := d.DB.Where("uuid = ? ", uuid).First(&flowNetworkModel).Error; err != nil {
+		return nil, err
+	}
+	return flowNetworkModel, nil
+}

--- a/database/proxy.go
+++ b/database/proxy.go
@@ -11,3 +11,11 @@ func (d *GormDatabase) GetFN(uuid string) (*model.FlowNetwork, error) {
 	}
 	return flowNetworkModel, nil
 }
+
+func (d *GormDatabase) GetFNC(uuid string) (*model.FlowNetworkClone, error) {
+	var flowNetworkCloneModel *model.FlowNetworkClone
+	if err := d.DB.Where("uuid = ? ", uuid).First(&flowNetworkCloneModel).Error; err != nil {
+		return nil, err
+	}
+	return flowNetworkCloneModel, nil
+}

--- a/database/wizardMasterSlave.go
+++ b/database/wizardMasterSlave.go
@@ -104,10 +104,7 @@ func (d *GormDatabase) WizardMasterSlavePointMappingOnConsumerSideByProducerSide
 	}
 
 	cli := client.NewFlowClientCli(fnc.FlowIP, fnc.FlowPort, fnc.FlowToken, fnc.IsMasterSlave, fnc.GlobalUUID, model.IsFNCreator(fnc))
-	rawProducers, err := cli.GetQueryMarshal(
-		urls.ProducerURL(),
-		map[string]string{"stream_uuid": streamClones[0].SourceUUID},
-		[]model.Producer{})
+	rawProducers, err := cli.GetQueryMarshal(urls.ProducerURLWithStream(streamClones[0].SourceUUID), []model.Producer{})
 	if err != nil {
 		return false, err
 	}

--- a/database/wizardMasterSlave.go
+++ b/database/wizardMasterSlave.go
@@ -5,6 +5,7 @@ import (
 	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/model"
 	"github.com/NubeDev/flow-framework/src/client"
+	"github.com/NubeDev/flow-framework/urls"
 	"github.com/NubeDev/flow-framework/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -103,10 +104,14 @@ func (d *GormDatabase) WizardMasterSlavePointMappingOnConsumerSideByProducerSide
 	}
 
 	cli := client.NewFlowClientCli(fnc.FlowIP, fnc.FlowPort, fnc.FlowToken, fnc.IsMasterSlave, fnc.GlobalUUID, model.IsFNCreator(fnc))
-	producers, err := cli.GetProducers(&streamClones[0].SourceUUID)
+	rawProducers, err := cli.GetQueryMarshal(
+		urls.ProducerURL(),
+		map[string]string{"stream_uuid": streamClones[0].SourceUUID},
+		[]model.Producer{})
 	if err != nil {
-		return false, fmt.Errorf("producer search failure: %s", err)
+		return false, err
 	}
+	producers := rawProducers.(*[]model.Producer)
 
 	consumerModel.Name = "ZATSP"
 	consumerModel.ProducerUUID = (*producers)[0].UUID

--- a/database/wizardP2P.go
+++ b/database/wizardP2P.go
@@ -160,10 +160,7 @@ func (d *GormDatabase) WizardP2PMappingOnConsumerSideByProducerSide(producerGlob
 	}
 
 	cli := client.NewFlowClientCli(fnc.FlowIP, fnc.FlowPort, fnc.FlowToken, fnc.IsMasterSlave, fnc.GlobalUUID, model.IsFNCreator(fnc))
-	rawProducers, err := cli.GetQueryMarshal(
-		urls.ProducerURL(),
-		map[string]string{"stream_uuid": streamClones[0].SourceUUID},
-		[]model.Producer{})
+	rawProducers, err := cli.GetQueryMarshal(urls.ProducerURLWithStream(streamClones[0].SourceUUID), []model.Producer{})
 	if err != nil {
 		return false, err
 	}

--- a/database/wizardP2P.go
+++ b/database/wizardP2P.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/model"
 	"github.com/NubeDev/flow-framework/src/client"
+	"github.com/NubeDev/flow-framework/urls"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -40,7 +41,10 @@ func (d *GormDatabase) WizardP2PMapping(body *model.P2PBody) (bool, error) {
 	}
 
 	cli := client.NewFlowClientCli(flow.FlowIP, flow.FlowPort, flow.FlowToken, flow.IsMasterSlave, flow.GlobalUUID, model.IsFNCreator(flow))
-	_, err = cli.WizardP2PMappingOnConsumerSideByProducerSide(deviceInfo.GlobalUUID)
+	//_, err = cli.WizardP2PMappingOnConsumerSideByProducerSide(deviceInfo.GlobalUUID)
+	url := fmt.Sprintf("/api/database/wizard/mapping/p2p/points/consumer/%s", deviceInfo.GlobalUUID)
+	fmt.Println("WizardP2PMappingOnConsumerSideByProducerSide>>> ", url)
+	_, err = cli.PostQuery(url, nil)
 	if err != nil {
 		return false, err
 	}
@@ -156,10 +160,14 @@ func (d *GormDatabase) WizardP2PMappingOnConsumerSideByProducerSide(producerGlob
 	}
 
 	cli := client.NewFlowClientCli(fnc.FlowIP, fnc.FlowPort, fnc.FlowToken, fnc.IsMasterSlave, fnc.GlobalUUID, model.IsFNCreator(fnc))
-	producers, err := cli.GetProducers(&streamClones[0].SourceUUID)
+	rawProducers, err := cli.GetQueryMarshal(
+		urls.ProducerURL(),
+		map[string]string{"stream_uuid": streamClones[0].SourceUUID},
+		[]model.Producer{})
 	if err != nil {
-		return false, fmt.Errorf("producer search failure: %s", err)
+		return false, err
 	}
+	producers := rawProducers.(*[]model.Producer)
 
 	consumerModel.Name = "ZATSP"
 	consumerModel.ProducerUUID = (*producers)[0].UUID

--- a/router/router.go
+++ b/router/router.go
@@ -154,11 +154,20 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 
 		fnProxy := apiRoutes.Group("/fn")
 		{
-			fnProxy.GET("/*any", proxyHandler.GetProxy())
-			fnProxy.POST("/*any", proxyHandler.PostProxy())
-			fnProxy.PUT("/*any", proxyHandler.PutProxy())
-			fnProxy.PATCH("/*any", proxyHandler.PatchProxy())
-			fnProxy.DELETE("/*any", proxyHandler.DeleteProxy())
+			fnProxy.GET("/*any", proxyHandler.GetProxy(true))
+			fnProxy.POST("/*any", proxyHandler.PostProxy(true))
+			fnProxy.PUT("/*any", proxyHandler.PutProxy(true))
+			fnProxy.PATCH("/*any", proxyHandler.PatchProxy(true))
+			fnProxy.DELETE("/*any", proxyHandler.DeleteProxy(true))
+		}
+
+		fncProxy := apiRoutes.Group("/fnc")
+		{
+			fncProxy.GET("/*any", proxyHandler.GetProxy(false))
+			fncProxy.POST("/*any", proxyHandler.PostProxy(false))
+			fncProxy.PUT("/*any", proxyHandler.PutProxy(false))
+			fncProxy.PATCH("/*any", proxyHandler.PatchProxy(false))
+			fncProxy.DELETE("/*any", proxyHandler.DeleteProxy(false))
 		}
 
 		requireClientsGroupRoutes := apiRoutes.Group("")

--- a/router/router.go
+++ b/router/router.go
@@ -4,20 +4,19 @@ import (
 	"fmt"
 	"github.com/NubeDev/flow-framework/auth"
 	"github.com/NubeDev/flow-framework/eventbus"
-	"time"
-
 	"github.com/NubeDev/flow-framework/floweng/server"
-	"github.com/NubeDev/flow-framework/logger"
-	"github.com/NubeDev/location"
 	"github.com/gin-contrib/cors"
+	"time"
 
 	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/api/stream"
 	"github.com/NubeDev/flow-framework/config"
 	"github.com/NubeDev/flow-framework/database"
 	"github.com/NubeDev/flow-framework/error"
+	"github.com/NubeDev/flow-framework/logger"
 	"github.com/NubeDev/flow-framework/model"
 	"github.com/NubeDev/flow-framework/plugin"
+	"github.com/NubeDev/location"
 	"github.com/gin-gonic/gin"
 )
 
@@ -28,6 +27,7 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 	engine.NoRoute(error.NotFound())
 	eventBus := eventbus.NewService(eventbus.GetBus())
 	streamHandler := stream.New(time.Duration(conf.Server.Stream.PingPeriodSeconds)*time.Second, 15*time.Second, conf.Server.Stream.AllowedOrigins, conf.Prod)
+	proxyHandler := api.Proxy{DB: db}
 	messageHandler := api.MessageAPI{Notifier: streamHandler, DB: db}
 	healthHandler := api.HealthAPI{DB: db}
 	clientHandler := api.ClientAPI{
@@ -142,6 +142,7 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 			ctx.Header(header, value)
 		}
 	})
+
 	engine.Use(cors.New(auth.CorsConfig(conf)))
 	engine.OPTIONS("/*any")
 
@@ -150,6 +151,15 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 		apiRoutes.GET("/version", func(ctx *gin.Context) {
 			ctx.JSON(200, vInfo)
 		})
+
+		fnProxy := apiRoutes.Group("/fn")
+		{
+			fnProxy.GET("/*any", proxyHandler.GetProxy())
+			fnProxy.POST("/*any", proxyHandler.PostProxy())
+			fnProxy.PUT("/*any", proxyHandler.PutProxy())
+			fnProxy.PATCH("/*any", proxyHandler.PatchProxy())
+			fnProxy.DELETE("/*any", proxyHandler.DeleteProxy())
+		}
 
 		requireClientsGroupRoutes := apiRoutes.Group("")
 		{

--- a/src/client/utils.go
+++ b/src/client/utils.go
@@ -6,18 +6,18 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-func (a *FlowClient) GetQuery(url string, params map[string]string) (*string, error) {
+func (a *FlowClient) GetQuery(url string) (*[]byte, error) {
 	resp, err := a.client.R().
-		SetPathParams(params).
 		Get(url)
 	e := checkError("GET", url, resp, err)
 	if e != nil {
 		return nil, *e
 	}
-	return utils.NewStringAddress(resp.String()), nil
+	output := resp.Body()
+	return &output, nil
 }
 
-func (a *FlowClient) PostQuery(url string, body interface{}) (*string, error) {
+func (a *FlowClient) PostQuery(url string, body interface{}) (*[]byte, error) {
 	resp, err := a.client.R().
 		SetBody(body).
 		Post(url)
@@ -25,10 +25,23 @@ func (a *FlowClient) PostQuery(url string, body interface{}) (*string, error) {
 	if e != nil {
 		return nil, *e
 	}
-	return utils.NewStringAddress(resp.String()), nil
+	output := resp.Body()
+	return &output, nil
 }
 
-func (a *FlowClient) PatchQuery(url string, body interface{}) (*string, error) {
+func (a *FlowClient) PutQuery(url string, body interface{}) (*[]byte, error) {
+	resp, err := a.client.R().
+		SetBody(body).
+		Patch(url)
+	e := checkError("PUT", url, resp, err)
+	if e != nil {
+		return nil, *e
+	}
+	output := resp.Body()
+	return &output, nil
+}
+
+func (a *FlowClient) PatchQuery(url string, body interface{}) (*[]byte, error) {
 	resp, err := a.client.R().
 		SetBody(body).
 		Patch(url)
@@ -36,12 +49,13 @@ func (a *FlowClient) PatchQuery(url string, body interface{}) (*string, error) {
 	if e != nil {
 		return nil, *e
 	}
-	return utils.NewStringAddress(resp.String()), nil
+	output := resp.Body()
+	return &output, nil
 }
 
 func (a *FlowClient) DeleteQuery(url string) error {
 	resp, err := a.client.R().
-		Patch(url)
+		Delete(url)
 	e := checkError("DELETE", url, resp, err)
 	if e != nil {
 		return *e
@@ -49,9 +63,8 @@ func (a *FlowClient) DeleteQuery(url string) error {
 	return nil
 }
 
-func (a *FlowClient) GetQueryMarshal(url string, params map[string]string, result interface{}) (interface{}, error) {
+func (a *FlowClient) GetQueryMarshal(url string, result interface{}) (interface{}, error) {
 	resp, err := a.client.R().
-		SetQueryParams(params).
 		SetResult(result).
 		Get(url)
 	e := checkError("GET", url, resp, err)
@@ -67,6 +80,18 @@ func (a *FlowClient) PostQueryMarshal(url string, body interface{}, result inter
 		SetResult(result).
 		Post(url)
 	e := checkError("POST", url, resp, err)
+	if e != nil {
+		return nil, *e
+	}
+	return resp.Result(), nil
+}
+
+func (a *FlowClient) PutQueryMarshal(url string, body interface{}, result interface{}) (interface{}, error) {
+	resp, err := a.client.R().
+		SetBody(body).
+		SetResult(result).
+		Put(url)
+	e := checkError("PUT", url, resp, err)
 	if e != nil {
 		return nil, *e
 	}

--- a/src/client/utils.go
+++ b/src/client/utils.go
@@ -1,0 +1,100 @@
+package client
+
+import (
+	"fmt"
+	"github.com/NubeDev/flow-framework/utils"
+	"github.com/go-resty/resty/v2"
+)
+
+func (a *FlowClient) GetQuery(url string, params map[string]string) (*string, error) {
+	resp, err := a.client.R().
+		SetPathParams(params).
+		Get(url)
+	e := checkError("GET", url, resp, err)
+	if e != nil {
+		return nil, *e
+	}
+	return utils.NewStringAddress(resp.String()), nil
+}
+
+func (a *FlowClient) PostQuery(url string, body interface{}) (*string, error) {
+	resp, err := a.client.R().
+		SetBody(body).
+		Post(url)
+	e := checkError("POST", url, resp, err)
+	if e != nil {
+		return nil, *e
+	}
+	return utils.NewStringAddress(resp.String()), nil
+}
+
+func (a *FlowClient) PatchQuery(url string, body interface{}) (*string, error) {
+	resp, err := a.client.R().
+		SetBody(body).
+		Patch(url)
+	e := checkError("PATCH", url, resp, err)
+	if e != nil {
+		return nil, *e
+	}
+	return utils.NewStringAddress(resp.String()), nil
+}
+
+func (a *FlowClient) DeleteQuery(url string) error {
+	resp, err := a.client.R().
+		Patch(url)
+	e := checkError("DELETE", url, resp, err)
+	if e != nil {
+		return *e
+	}
+	return nil
+}
+
+func (a *FlowClient) GetQueryMarshal(url string, params map[string]string, result interface{}) (interface{}, error) {
+	resp, err := a.client.R().
+		SetQueryParams(params).
+		SetResult(result).
+		Get(url)
+	e := checkError("GET", url, resp, err)
+	if e != nil {
+		return nil, *e
+	}
+	return resp.Result(), nil
+}
+
+func (a *FlowClient) PostQueryMarshal(url string, body interface{}, result interface{}) (interface{}, error) {
+	resp, err := a.client.R().
+		SetBody(body).
+		SetResult(result).
+		Post(url)
+	e := checkError("POST", url, resp, err)
+	if e != nil {
+		return nil, *e
+	}
+	return resp.Result(), nil
+}
+
+func (a *FlowClient) PatchQueryMarshal(url string, body interface{}, result interface{}) (interface{}, error) {
+	resp, err := a.client.R().
+		SetBody(body).
+		SetResult(result).
+		Patch(url)
+	e := checkError("PATCH", url, resp, err)
+	if e != nil {
+		return nil, *e
+	}
+	return resp.Result(), nil
+}
+
+func checkError(method string, url string, resp *resty.Response, err error) *error {
+	if err != nil {
+		if resp == nil || resp.String() == "" {
+			return utils.NewError(fmt.Errorf("%s %s: %s", method, url, err))
+		} else {
+			return utils.NewError(fmt.Errorf("%s %s: %s", method, url, resp))
+		}
+	}
+	if resp.IsError() {
+		return utils.NewError(fmt.Errorf("%s %s: %s", method, url, resp))
+	}
+	return nil
+}

--- a/urls/urls.go
+++ b/urls/urls.go
@@ -2,14 +2,14 @@ package urls
 
 import "fmt"
 
-var (
-	producerURL = "/api/producers"
-)
-
 func ProducerURL() string {
-	return producerURL
+	return "/api/producers"
+}
+
+func ProducerURLWithStream(streamUUID string) string {
+	return fmt.Sprintf("%s?stream_uuid=%s", ProducerURL(), streamUUID)
 }
 
 func ProducerSingularURL(uuid string) string {
-	return fmt.Sprintf("%s/%s", producerURL, uuid)
+	return fmt.Sprintf("%s/%s", ProducerURL(), uuid)
 }

--- a/urls/urls.go
+++ b/urls/urls.go
@@ -1,0 +1,15 @@
+package urls
+
+import "fmt"
+
+var (
+	producerURL = "/api/producers"
+)
+
+func ProducerURL() string {
+	return producerURL
+}
+
+func ProducerSingularURL(uuid string) string {
+	return fmt.Sprintf("%s/%s", producerURL, uuid)
+}

--- a/utils/error.go
+++ b/utils/error.go
@@ -1,0 +1,6 @@
+package utils
+
+func NewError(err error) *error {
+	e := err
+	return &e
+}


### PR DESCRIPTION
### Includes

- Improvement on `resty` query
- Proxy request via `flow_network.uuid`
- Proxy request via f`low_network_clones.uuid`

### Examples

- `/api/fn/fln_0f2be8730c3d4530/api/flow_networks?with_streams=true` (getting flow_networks with streams from `flow_network.uuid`)
- `/api/fnc/rfn_69acbe9caeff4c3b/api/networks?with_streams=true` (getting flow_networks with streams from `flow_network_clones.uuid`)
- `/api/fnc/<:flow_network_clone.uuid>/streams/<:stream_clone.source_uuid>?with_producers=true` (to get producers for stream_clone from `stream_clone.source_uuid` with `flow_network_clone.uuid`)