### PR TITLE
Feature/schema api

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -128,6 +128,9 @@ jobs:
           cd ../../../../plugin/nube/database/influx
           go build -buildmode=plugin -o influx-amd64.so *.go  && cp influx-amd64.so ../../../../
 
+          cd ../../../../plugin/nube/database/history
+          go build -buildmode=plugin -o history-amd64.so *.go  && cp history-amd64.so ../../../../
+
           cd ../../../../plugin/nube/protocals/broker
           go build -buildmode=plugin -o broker-amd64.so *.go  && cp broker-amd64.so ../../../../
 
@@ -173,6 +176,9 @@ jobs:
 
           cd ../../../../plugin/nube/database/influx
           env GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc  CXX=arm-linux-gnueabihf-g++ go build -buildmode=plugin -o influx-armv7.so *.go  && cp influx-armv7.so ../../../../
+
+          cd ../../../../plugin/nube/database/history
+          env GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc  CXX=arm-linux-gnueabihf-g++ go build -buildmode=plugin -o history-armv7.so *.go  && cp history-armv7.so ../../../../
 
           cd ../../../../plugin/nube/protocals/broker
           env GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc  CXX=arm-linux-gnueabihf-g++ go build -buildmode=plugin -o broker-armv7.so *.go  && cp broker-armv7.so ../../../../
@@ -245,6 +251,11 @@ jobs:
           zip -r /tmp/zip/$artifact.zip ./influx-amd64.so
           artifact=influx-${{ needs.context.outputs.version }}-${{ needs.context.outputs.shortCommitId }}.armv7
           zip -r /tmp/zip/$artifact.zip ./influx-armv7.so
+
+          artifact=history-${{ needs.context.outputs.version }}-${{ needs.context.outputs.shortCommitId }}.amd64
+          zip -r /tmp/zip/$artifact.zip ./history-amd64.so
+          artifact=history-${{ needs.context.outputs.version }}-${{ needs.context.outputs.shortCommitId }}.armv7
+          zip -r /tmp/zip/$artifact.zip ./history-armv7.so
 
           artifact=broker-${{ needs.context.outputs.version }}-${{ needs.context.outputs.shortCommitId }}.amd64
           zip -r /tmp/zip/$artifact.zip ./broker-amd64.so

--- a/api/argsBuilder.go
+++ b/api/argsBuilder.go
@@ -163,8 +163,6 @@ func buildNetworkArgs(ctx *gin.Context) Args {
 	var aDefault = ArgsDefault
 	args.WithDevices, _ = toBool(ctx.DefaultQuery(aType.WithDevices, aDefault.WithDevices))
 	args.WithPoints, _ = toBool(ctx.DefaultQuery(aType.WithPoints, aDefault.WithPoints))
-	args.WithIpConnection, _ = toBool(ctx.DefaultQuery(aType.WithIpConnection, aDefault.WithIpConnection))
-	args.WithSerialConnection, _ = toBool(ctx.DefaultQuery(aType.WithSerialConnection, aDefault.WithSerialConnection))
 	args.WithTags, _ = toBool(ctx.DefaultQuery(aType.WithTags, aDefault.WithTags))
 	return args
 }
@@ -174,8 +172,6 @@ func buildDeviceArgs(ctx *gin.Context) Args {
 	var aType = ArgsType
 	var aDefault = ArgsDefault
 	args.WithPoints, _ = toBool(ctx.DefaultQuery(aType.WithPoints, aDefault.WithPoints))
-	args.WithIpConnection, _ = toBool(ctx.DefaultQuery(aType.WithIpConnection, aDefault.WithIpConnection))
-	args.WithSerialConnection, _ = toBool(ctx.DefaultQuery(aType.WithSerialConnection, aDefault.WithSerialConnection))
 	args.WithTags, _ = toBool(ctx.DefaultQuery(aType.WithTags, aDefault.WithTags))
 	return args
 }

--- a/api/internalUtils.go
+++ b/api/internalUtils.go
@@ -57,8 +57,6 @@ type Args struct {
 	WithDevices          bool
 	WithPoints           bool
 	WithPriority         bool
-	WithIpConnection     bool
-	WithSerialConnection bool
 	WithTags             bool
 	NetworkName          string
 	DeviceName           string
@@ -113,8 +111,6 @@ var ArgsType = struct {
 	WithDevices          string
 	WithPoints           string
 	WithPriority         string
-	WithIpConnection     string
-	WithSerialConnection string
 	WithTags             string
 	NetworkName          string
 	DeviceName           string
@@ -167,8 +163,6 @@ var ArgsType = struct {
 	WithDevices:          "with_devices",
 	WithPoints:           "with_points",
 	WithPriority:         "with_priority",
-	WithIpConnection:     "with_ip_connection",
-	WithSerialConnection: "with_serial_connection",
 	WithTags:             "with_tags",
 	NetworkName:          "network_name",
 	DeviceName:           "device_name",
@@ -177,86 +171,82 @@ var ArgsType = struct {
 }
 
 var ArgsDefault = struct {
-	Sort                 string
-	Order                string
-	Offset               string
-	Limit                string
-	Search               string
-	AskRefresh           string
-	AskResponse          string
-	Write                string
-	ThingType            string
-	FlowNetworkUUID      string
-	Field                string
-	Value                string
-	UpdateProducer       string
-	CompactPayload       string
-	CompactWithName      string
-	FlowUUID             string
-	StreamUUID           string
-	ProducerUUID         string
-	ConsumerUUID         string
-	WriterUUID           string
-	AddToParent          string
-	PluginName           string
-	WithFlowNetworks     string
-	WithStreams          string
-	WithStreamClones     string
-	WithProducers        string
-	WithConsumers        string
-	WithCommandGroups    string
-	WithWriters          string
-	WithWriterClones     string
-	WithNetworks         string
-	WithDevices          string
-	WithPoints           string
-	WithPriority         string
-	WithIpConnection     string
-	WithSerialConnection string
-	WithTags             string
-	NetworkName          string
-	DeviceName           string
-	PointName            string
+	Sort              string
+	Order             string
+	Offset            string
+	Limit             string
+	Search            string
+	AskRefresh        string
+	AskResponse       string
+	Write             string
+	ThingType         string
+	FlowNetworkUUID   string
+	Field             string
+	Value             string
+	UpdateProducer    string
+	CompactPayload    string
+	CompactWithName   string
+	FlowUUID          string
+	StreamUUID        string
+	ProducerUUID      string
+	ConsumerUUID      string
+	WriterUUID        string
+	AddToParent       string
+	PluginName        string
+	WithFlowNetworks  string
+	WithStreams       string
+	WithStreamClones  string
+	WithProducers     string
+	WithConsumers     string
+	WithCommandGroups string
+	WithWriters       string
+	WithWriterClones  string
+	WithNetworks      string
+	WithDevices       string
+	WithPoints        string
+	WithPriority      string
+	WithTags          string
+	NetworkName       string
+	DeviceName        string
+	PointName         string
 }{
-	Sort:                 "ID",
-	Order:                "DESC", //ASC or DESC
-	Offset:               "0",
-	Limit:                "25",
-	Search:               "",
-	AskRefresh:           "false",
-	AskResponse:          "false",
-	Write:                "false",
-	ThingType:            "point",
-	FlowNetworkUUID:      "",
-	Field:                "name",
-	Value:                "",
-	UpdateProducer:       "false",
-	CompactPayload:       "false",
-	CompactWithName:      "false",
-	FlowUUID:             "",
-	ProducerUUID:         "",
-	ConsumerUUID:         "",
-	WriterUUID:           "",
-	AddToParent:          "",
-	PluginName:           "false",
-	WithFlowNetworks:     "false",
-	WithStreams:          "false",
-	WithStreamClones:     "false",
-	WithProducers:        "false",
-	WithConsumers:        "false",
-	WithCommandGroups:    "false",
-	WithWriters:          "false",
-	WithWriterClones:     "false",
-	WithNetworks:         "false",
-	WithDevices:          "false",
-	WithPoints:           "false",
-	WithPriority:         "false",
-	WithIpConnection:     "false",
-	WithSerialConnection: "false",
-	WithTags:             "false",
-	NetworkName:          "",
-	DeviceName:           "",
-	PointName:            "",
+	Sort:              "ID",
+	Order:             "DESC", //ASC or DESC
+	Offset:            "0",
+	Limit:             "25",
+	Search:            "",
+	AskRefresh:        "false",
+	AskResponse:       "false",
+	Write:             "false",
+	ThingType:         "point",
+	FlowNetworkUUID:   "",
+	Field:             "name",
+	Value:             "",
+	UpdateProducer:    "false",
+	CompactPayload:    "false",
+	CompactWithName:   "false",
+	FlowUUID:          "",
+	ProducerUUID:      "",
+	ConsumerUUID:      "",
+	WriterUUID:        "",
+	AddToParent:       "",
+	PluginName:        "false",
+	WithFlowNetworks:  "false",
+	WithStreams:       "false",
+	WithStreamClones:  "false",
+	WithProducers:     "false",
+	WithConsumers:     "false",
+	WithCommandGroups: "false",
+	WithWriters:       "false",
+	WithWriterClones:  "false",
+	WithNetworks:      "false",
+	WithDevices:       "false",
+	WithPoints:        "false",
+	WithPriority:      "false",
+	WithTags:          "false",
+	NetworkName:       "",
+	DeviceName:        "",
+	PointName:         "",
 }
 
 type Message struct {

--- a/api/plugin.go
+++ b/api/plugin.go
@@ -109,14 +109,16 @@ func (c *PluginAPI) EnablePluginByUUID(ctx *gin.Context) {
 		return
 	}
 	if err := c.Manager.SetPluginEnabled(uuid, body.Enabled); err == plugin.ErrAlreadyEnabledOrDisabled {
-		reposeHandler("err:", err, ctx)
+		reposeHandler("", err, ctx)
+		return
 	} else if err != nil {
-		reposeHandler("err:", err, ctx)
+		reposeHandler("", err, ctx)
+		return
 	}
 	if body.Enabled {
-		reposeHandler("enabled", err, ctx)
+		reposeHandler(map[string]string{"state": "enabled"}, err, ctx)
 	} else {
-		reposeHandler("disabled", err, ctx)
+		reposeHandler(map[string]string{"state": "disabled"}, err, ctx)
 	}
 }
 

--- a/api/plugin.go
+++ b/api/plugin.go
@@ -58,6 +58,7 @@ func (c *PluginAPI) GetPlugins(ctx *gin.Context) {
 				Website:      info.Website,
 				License:      info.License,
 				Enabled:      conf.Enabled,
+				HasNetwork:   conf.HasNetwork,
 				Capabilities: inst.Supports().Strings(),
 			})
 		}

--- a/build.bash
+++ b/build.bash
@@ -49,20 +49,17 @@ mkdir -p $pluginDir
 cd $dir/plugin/nube/system/
 go build -buildmode=plugin -o system.so *.go  && cp system.so  $pluginDir
 
-cd $dir/plugin/nube/networking/rubixnet
-go build -buildmode=plugin -o rubixnet.so *.go  && cp rubixnet.so  $pluginDir
-
-cd $dir/plugin/nube/protocals/rubix
-go build -buildmode=plugin -o rubix.so *.go  && cp rubix.so $pluginDir
-
 cd $dir/plugin/nube/utils/backup
 go build -buildmode=plugin -o backup.so *.go  && cp backup.so  $pluginDir
 
-cd $dir/plugin/nube/utils/git
-go build -buildmode=plugin -o git.so *.go  && cp git.so  $pluginDir
+cd $dir/plugin/nube/utils/mqttapi
+go build -buildmode=plugin -o mqttapi.so *.go  && cp mqttapi.so  $pluginDir
 
 cd $dir/plugin/nube/utils/git
 go build -buildmode=plugin -o git.so *.go  && cp git.so  $pluginDir
+
+cd $dir/plugin/nube/networking/rubixnet
+go build -buildmode=plugin -o rubixnet.so *.go  && cp rubixnet.so  $pluginDir
 
 cd $dir/plugin/nube/protocals/edge28
 go build -buildmode=plugin -o edge28.so *.go  && cp edge28.so $pluginDir
@@ -76,11 +73,17 @@ go build -buildmode=plugin -o modbus.so *.go  && cp modbus.so $pluginDir
 cd $dir/plugin/nube/protocals/lora
 go build -buildmode=plugin -o lora.so *.go  && cp lora.so $pluginDir
 
+cd $dir/plugin/nube/protocals/rubix
+go build -buildmode=plugin -o rubix.so *.go  && cp rubix.so $pluginDir
+
 cd $dir/plugin/nube/protocals/bacnetserver
 go build -buildmode=plugin -o bacnetserver.so *.go  && cp bacnetserver.so $pluginDir
 
 cd $dir/plugin/nube/database/influx
 go build -buildmode=plugin -o influx.so *.go  && cp influx.so $pluginDir
+
+cd $dir/plugin/nube/database/history
+go build -buildmode=plugin -o history.so *.go  && cp history.so $pluginDir
 
 cd $dir/plugin/nube/protocals/broker
 go build -buildmode=plugin -o broker.so *.go  && cp broker.so $pluginDir

--- a/database/database.go
+++ b/database/database.go
@@ -52,8 +52,6 @@ func New(dialect, connection, logLevel string) (*GormDatabase, error) {
 	var writerClone []model.WriterClone
 	var integration []model.Integration
 	var mqttConnection []model.MqttConnection
-	var serialConnection []model.SerialConnection
-	var ipConnection []model.IpConnection
 	var schedule []model.Schedule
 	var tags []model.Tag
 	var blocks []model.Block
@@ -89,8 +87,6 @@ func New(dialect, connection, logLevel string) (*GormDatabase, error) {
 		&writerClone,
 		&integration,
 		&mqttConnection,
-		&serialConnection,
-		&ipConnection,
 		&schedule,
 		&tags,
 		&blocks,

--- a/database/queryBuilder.go
+++ b/database/queryBuilder.go
@@ -137,12 +137,6 @@ func (d *GormDatabase) buildNetworkQuery(args api.Args) *gorm.DB {
 	if args.WithPoints {
 		query = query.Preload("Devices.Points").Preload("Devices.Points.Priority")
 	}
-	if args.WithIpConnection {
-		query = query.Preload("IpConnection")
-	}
-	if args.WithSerialConnection {
-		query = query.Preload("SerialConnection")
-	}
 	if args.WithTags {
 		query = query.Preload("Tags")
 	}

--- a/model/networks.go
+++ b/model/networks.go
@@ -29,11 +29,18 @@ type Network struct {
 	CommonThingClass
 	CommonThingRef
 	CommonThingType
-	TransportType    string            `json:"transport_type,omitempty"  gorm:"type:varchar(255);not null"` //serial
-	PluginConfId     string            `json:"plugin_conf_id,omitempty" gorm:"TYPE:varchar(255) REFERENCES plugin_confs;not null;default:null"`
-	PluginPath       string            `json:"plugin_name,omitempty"`
-	Devices          []*Device         `json:"devices,omitempty" gorm:"constraint:OnDelete:CASCADE"`
-	SerialConnection *SerialConnection `json:"serial_connection,omitempty" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
-	IpConnection     *IpConnection     `json:"ip_connection,omitempty" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
-	Tags             []*Tag            `json:"tags,omitempty" gorm:"many2many:networks_tags;constraint:OnDelete:CASCADE"`
+	TransportType   string    `json:"transport_type,omitempty"  gorm:"type:varchar(255);not null"` //serial
+	PluginConfId    string    `json:"plugin_conf_id,omitempty" gorm:"TYPE:varchar(255) REFERENCES plugin_confs;not null;default:null"`
+	PluginPath      string    `json:"plugin_name,omitempty"`
+	SerialPort      *string   `json:"serial_port,omitempty" gorm:"type:varchar(255);unique"`
+	SerialBaudRate  *uint     `json:"serial_baud_rate,omitempty"` //9600
+	SerialStopBits  *uint     `json:"serial_stop_bits,omitempty"`
+	SerialParity    *string   `json:"serial_parity,omitempty"`
+	SerialDataBits  *uint     `json:"serial_data_bits,omitempty"`
+	SerialTimeout   *int      `json:"serial_timeout,omitempty"`
+	SerialConnected *bool     `json:"serial_connected,omitempty"`
+	Host            *string   `json:"host,omitempty"`
+	Port            *int      `json:"port,omitempty"`
+	Devices         []*Device `json:"devices,omitempty" gorm:"constraint:OnDelete:CASCADE"`
+	Tags            []*Tag    `json:"tags,omitempty" gorm:"many2many:networks_tags;constraint:OnDelete:CASCADE"`
 }

--- a/model/pluginconf.go
+++ b/model/pluginconf.go
@@ -6,6 +6,7 @@ type PluginConf struct {
 	Name        string `json:"name" gorm:"name:varchar(255);not null"`
 	ModulePath  string `json:"module_path"  gorm:"type:varchar(255);unique;not null"`
 	Enabled     bool   `json:"enabled"`
+	HasNetwork  bool   `json:"has_network"`
 	Config      []byte
 	Storage     []byte
 	Network     Network     `json:"networks" gorm:"constraint:OnDelete:CASCADE"`
@@ -23,6 +24,7 @@ type PluginConfExternal struct {
 	Website      string        `json:"website,omitempty" form:"website" query:"website"`
 	License      string        `json:"license,omitempty" form:"license" query:"license"`
 	Enabled      bool          `json:"enabled"`
+	HasNetwork   bool          `json:"has_network"`
 	ProtocolType string        `json:"protocol_type" gorm:"type:varchar(255);not null"`
 	Capabilities []string      `json:"capabilities"`
 	Network      Network       `json:"networks" gorm:"constraint:OnDelete:CASCADE"`

--- a/model/transport.go
+++ b/model/transport.go
@@ -59,31 +59,3 @@ var SerialParity = struct {
 	Odd:  "odd",
 	Even: "even",
 }
-
-type SerialConnection struct {
-	CommonUUID
-	CommonEnable
-	SerialPort  string `json:"serial_port" gorm:"type:varchar(255);unique"`
-	BaudRate    uint   `json:"baud_rate"` //9600
-	StopBits    uint   `json:"stop_bits"`
-	Parity      string `json:"parity"`
-	DataBits    uint   `json:"data_bits"`
-	Timeout     int    `json:"timeout"`
-	Connected   bool   `json:"connected"`
-	Error       bool   `json:"error"`
-	NetworkUUID string `json:"network_uuid" gorm:"TYPE:varchar(255) REFERENCES networks"`
-}
-
-type IpConnection struct {
-	CommonUUID
-	Host        string `json:"host"`
-	Port        int    `json:"port"`
-	NetworkUUID string `json:"network_uuid" gorm:"TYPE:varchar(255) REFERENCES networks"`
-}
-
-type TransportBody struct {
-	NetworkType      string           `json:"network_type"`
-	TransportType    string           `json:"transport_type"`
-	IpConnection     IpConnection     `json:"ip_connection"`
-	SerialConnection SerialConnection `json:"serial_connection"`
-}

--- a/plugin/compat/plugin.go
+++ b/plugin/compat/plugin.go
@@ -16,6 +16,7 @@ type Info struct {
 	Description string
 	License     string
 	ModulePath  string
+	HasNetwork  bool
 }
 
 func (c Info) String() string {

--- a/plugin/compat/v1.go
+++ b/plugin/compat/v1.go
@@ -31,6 +31,7 @@ func (c PluginV1) PluginInfo() Info {
 		Description: c.Info.Description,
 		License:     c.Info.License,
 		ModulePath:  c.Info.ModulePath,
+		HasNetwork:  c.Info.HasNetwork,
 	}
 }
 

--- a/plugin/defaults/defaults.go
+++ b/plugin/defaults/defaults.go
@@ -1,0 +1,193 @@
+package defaults
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+var (
+	errInvalidType = errors.New("not a struct pointer")
+)
+
+const (
+	fieldName = "default"
+)
+
+// Set initializes members in a struct referenced by a pointer.
+// Maps and slices are initialized by `make` and other primitive types are set with default values.
+// `ptr` should be a struct pointer
+func Set(ptr interface{}) error {
+	if reflect.TypeOf(ptr).Kind() != reflect.Ptr {
+		return errInvalidType
+	}
+
+	v := reflect.ValueOf(ptr).Elem()
+	t := v.Type()
+
+	if t.Kind() != reflect.Struct {
+		return errInvalidType
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		if defaultVal := t.Field(i).Tag.Get(fieldName); defaultVal != "-" {
+			if err := setField(v.Field(i), defaultVal); err != nil {
+				return err
+			}
+		}
+	}
+	callSetter(ptr)
+	return nil
+}
+
+// MustSet function is a wrapper of Set function
+// It will call Set and panic if err not equals nil.
+func MustSet(ptr interface{}) {
+	if err := Set(ptr); err != nil {
+		panic(err)
+	}
+}
+
+func setField(field reflect.Value, defaultVal string) error {
+	if !field.CanSet() {
+		return nil
+	}
+
+	if !shouldInitializeField(field, defaultVal) {
+		return nil
+	}
+
+	isInitial := isInitialValue(field)
+	if isInitial {
+		switch field.Kind() {
+		case reflect.Bool:
+			if val, err := strconv.ParseBool(defaultVal); err == nil {
+				field.Set(reflect.ValueOf(val).Convert(field.Type()))
+			}
+		case reflect.Int:
+			if val, err := strconv.ParseInt(defaultVal, 0, strconv.IntSize); err == nil {
+				field.Set(reflect.ValueOf(int(val)).Convert(field.Type()))
+			}
+		case reflect.Int8:
+			if val, err := strconv.ParseInt(defaultVal, 0, 8); err == nil {
+				field.Set(reflect.ValueOf(int8(val)).Convert(field.Type()))
+			}
+		case reflect.Int16:
+			if val, err := strconv.ParseInt(defaultVal, 0, 16); err == nil {
+				field.Set(reflect.ValueOf(int16(val)).Convert(field.Type()))
+			}
+		case reflect.Int32:
+			if val, err := strconv.ParseInt(defaultVal, 0, 32); err == nil {
+				field.Set(reflect.ValueOf(int32(val)).Convert(field.Type()))
+			}
+		case reflect.Int64:
+			if val, err := time.ParseDuration(defaultVal); err == nil {
+				field.Set(reflect.ValueOf(val).Convert(field.Type()))
+			} else if val, err := strconv.ParseInt(defaultVal, 0, 64); err == nil {
+				field.Set(reflect.ValueOf(val).Convert(field.Type()))
+			}
+		case reflect.Uint:
+			if val, err := strconv.ParseUint(defaultVal, 0, strconv.IntSize); err == nil {
+				field.Set(reflect.ValueOf(uint(val)).Convert(field.Type()))
+			}
+		case reflect.Uint8:
+			if val, err := strconv.ParseUint(defaultVal, 0, 8); err == nil {
+				field.Set(reflect.ValueOf(uint8(val)).Convert(field.Type()))
+			}
+		case reflect.Uint16:
+			if val, err := strconv.ParseUint(defaultVal, 0, 16); err == nil {
+				field.Set(reflect.ValueOf(uint16(val)).Convert(field.Type()))
+			}
+		case reflect.Uint32:
+			if val, err := strconv.ParseUint(defaultVal, 0, 32); err == nil {
+				field.Set(reflect.ValueOf(uint32(val)).Convert(field.Type()))
+			}
+		case reflect.Uint64:
+			if val, err := strconv.ParseUint(defaultVal, 0, 64); err == nil {
+				field.Set(reflect.ValueOf(val).Convert(field.Type()))
+			}
+		case reflect.Uintptr:
+			if val, err := strconv.ParseUint(defaultVal, 0, strconv.IntSize); err == nil {
+				field.Set(reflect.ValueOf(uintptr(val)).Convert(field.Type()))
+			}
+		case reflect.Float32:
+			if val, err := strconv.ParseFloat(defaultVal, 32); err == nil {
+				field.Set(reflect.ValueOf(float32(val)).Convert(field.Type()))
+			}
+		case reflect.Float64:
+			if val, err := strconv.ParseFloat(defaultVal, 64); err == nil {
+				field.Set(reflect.ValueOf(val).Convert(field.Type()))
+			}
+		case reflect.String:
+			field.Set(reflect.ValueOf(defaultVal).Convert(field.Type()))
+
+		case reflect.Slice:
+			ref := reflect.New(field.Type())
+			ref.Elem().Set(reflect.MakeSlice(field.Type(), 0, 0))
+			if defaultVal != "" && defaultVal != "[]" {
+				if err := json.Unmarshal([]byte(defaultVal), ref.Interface()); err != nil {
+					return err
+				}
+			}
+			field.Set(ref.Elem().Convert(field.Type()))
+		case reflect.Map:
+			ref := reflect.New(field.Type())
+			ref.Elem().Set(reflect.MakeMap(field.Type()))
+			if defaultVal != "" && defaultVal != "{}" {
+				if err := json.Unmarshal([]byte(defaultVal), ref.Interface()); err != nil {
+					return err
+				}
+			}
+			field.Set(ref.Elem().Convert(field.Type()))
+		case reflect.Struct:
+			if defaultVal != "" && defaultVal != "{}" {
+				if err := json.Unmarshal([]byte(defaultVal), field.Addr().Interface()); err != nil {
+					return err
+				}
+			}
+		case reflect.Ptr:
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+	}
+
+	switch field.Kind() {
+	case reflect.Ptr:
+		if isInitial || field.Elem().Kind() == reflect.Struct {
+			setField(field.Elem(), defaultVal)
+			callSetter(field.Interface())
+		}
+	case reflect.Struct:
+		if err := Set(field.Addr().Interface()); err != nil {
+			return err
+		}
+	case reflect.Slice:
+		for j := 0; j < field.Len(); j++ {
+			if err := setField(field.Index(j), defaultVal); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func isInitialValue(field reflect.Value) bool {
+	return reflect.DeepEqual(reflect.Zero(field.Type()).Interface(), field.Interface())
+}
+
+func shouldInitializeField(field reflect.Value, tag string) bool {
+	switch field.Kind() {
+	case reflect.Struct:
+		return true
+	case reflect.Ptr:
+		if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
+			return true
+		}
+	case reflect.Slice:
+		return field.Len() > 0 || tag != ""
+	}
+
+	return tag != ""
+}

--- a/plugin/defaults/setter.go
+++ b/plugin/defaults/setter.go
@@ -1,0 +1,13 @@
+package defaults
+
+// Setter is an interface for setting default values
+type Setter interface {
+	SetDefaults()
+}
+
+func callSetter(v interface{}) {
+	if ds, ok := v.(Setter); ok {
+		ds.SetDefaults()
+
+	}
+}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -249,7 +249,7 @@ func (m *Manager) initializePlugin(p compat.Plugin) error {
 	if compat.HasSupport(instance, compat.Webhooker) {
 		uuid := pluginConf.UUID
 		path := pluginConf.ModulePath
-		g := m.mux.Group("/", requirePluginEnabled(uuid, m.db))
+		g := m.mux.Group("/"+path, requirePluginEnabled(uuid, m.db))
 		instance.RegisterWebhook(strings.Replace(g.BasePath(), ":id", path, 1), g) //change path to uuid if we want the url to register as uuid
 	}
 	if pluginConf.Enabled {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -86,7 +86,7 @@ func NewManager(db Database, directory string, mux *gin.RouterGroup, notifier No
 }
 
 // ErrAlreadyEnabledOrDisabled is returned on SetPluginEnabled call when a plugin is already enabled or disabled.
-var ErrAlreadyEnabledOrDisabled = errors.New("config is already enabled/disabled")
+var ErrAlreadyEnabledOrDisabled = errors.New("config is already on your state")
 
 // SetPluginEnabled sets the plugins enabled state.
 func (m *Manager) SetPluginEnabled(pluginID string, enabled bool) error {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -302,6 +302,7 @@ func (m *Manager) createPluginConf(instance compat.PluginInstance, info compat.I
 	pluginConf := &model.PluginConf{
 		Name:       info.Name,
 		ModulePath: info.ModulePath,
+		HasNetwork: info.HasNetwork,
 	}
 	if compat.HasSupport(instance, compat.Configurer) {
 		pluginConf.Config, _ = yaml.Marshal(instance.DefaultConfig())

--- a/plugin/nube/database/history/main.go
+++ b/plugin/nube/database/history/main.go
@@ -51,7 +51,7 @@ func GetFlowPluginInfo() plugin.Info {
 }
 
 // NewFlowPluginInstance creates a plugin instance for a user context.
-func NewFlowPluginInstance(ctx plugin.UserContext) plugin.Plugin {
+func NewFlowPluginInstance() plugin.Plugin {
 	return &Instance{}
 }
 

--- a/plugin/nube/database/influx/app.go
+++ b/plugin/nube/database/influx/app.go
@@ -32,7 +32,8 @@ func (i *Instance) syncInflux() (bool, error) {
 		}
 		historyCount := len(histories)
 		if historyCount > 0 {
-			_, err := i.db.UpdateHistoryLogLastSyncId(histories[historyCount-1].ID)
+			// TODO: Enju
+			//_, err := i.db.UpdateHistoryLogLastSyncId(histories[historyCount-1].ID)
 			if err != nil {
 				return false, err
 			}

--- a/plugin/nube/networking/rubixnet/app.go
+++ b/plugin/nube/networking/rubixnet/app.go
@@ -100,8 +100,6 @@ func (i *Instance) backNetworks() error {
 	var arg api.Args
 	arg.WithDevices = true
 	arg.WithPoints = true
-	arg.WithSerialConnection = true
-	arg.WithIpConnection = true
 
 	nets, err := i.db.GetNetworks(arg)
 	if err != nil {

--- a/plugin/nube/protocals/bacnetserver/api.go
+++ b/plugin/nube/protocals/bacnetserver/api.go
@@ -1,20 +1,26 @@
 package main
 
 import (
-	pkgmodel "github.com/NubeDev/flow-framework/plugin/nube/protocals/bacnetserver/model"
-	plgrest "github.com/NubeDev/flow-framework/plugin/nube/protocals/bacnetserver/restclient"
+	"github.com/NubeDev/flow-framework/plugin/nube/protocals/bacnetserver/model"
+	"github.com/NubeDev/flow-framework/plugin/nube/protocals/bacnetserver/plgrest"
 	"github.com/NubeDev/flow-framework/utils"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 	"net/http"
 )
 
-func getBODYNetwork(ctx *gin.Context) (dto *pkgmodel.Server, err error) {
+const (
+	schemaNetwork = "/schema/network"
+	schemaDevice  = "/schema/device"
+	schemaPoint   = "/schema/point"
+)
+
+func getBODYNetwork(ctx *gin.Context) (dto *model.Server, err error) {
 	err = ctx.ShouldBindJSON(&dto)
 	return dto, err
 }
 
-func getBODYPoints(ctx *gin.Context) (dto *pkgmodel.BacnetPoint, err error) {
+func getBODYPoints(ctx *gin.Context) (dto *model.BacnetPoint, err error) {
 	err = ctx.ShouldBindJSON(&dto)
 	return dto, err
 }
@@ -121,5 +127,17 @@ func (i *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 		} else {
 			ctx.JSON(http.StatusOK, wizard)
 		}
+	})
+
+	mux.GET(schemaNetwork, func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, model.GetNetworkSchema())
+	})
+
+	mux.GET(schemaDevice, func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, model.GetDeviceSchema())
+	})
+
+	mux.GET(schemaPoint, func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, model.GetPointSchema())
 	})
 }

--- a/plugin/nube/protocals/bacnetserver/enable.go
+++ b/plugin/nube/protocals/bacnetserver/enable.go
@@ -10,9 +10,7 @@ func (i *Instance) Enable() error {
 	i.enabled = true
 	i.setUUID()
 	i.BusServ()
-	var arg api.Args
-	arg.WithIpConnection = true
-	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, arg)
+	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, api.Args{})
 	if q != nil {
 		i.networkUUID = q.UUID
 	} else {

--- a/plugin/nube/protocals/bacnetserver/main.go
+++ b/plugin/nube/protocals/bacnetserver/main.go
@@ -43,6 +43,7 @@ func GetFlowPluginInfo() plugin.Info {
 		Description:  description,
 		Author:       author,
 		Website:      webSite,
+		HasNetwork:   true,
 		ProtocolType: protocolType,
 	}
 }

--- a/plugin/nube/protocals/bacnetserver/model/model.go
+++ b/plugin/nube/protocals/bacnetserver/model/model.go
@@ -1,7 +1,8 @@
-package pkgmodel
+package model
 
 import (
 	"github.com/NubeDev/flow-framework/model"
+	"github.com/NubeDev/flow-framework/plugin/defaults"
 )
 
 type ServerPing struct {
@@ -57,4 +58,51 @@ type BacnetPoint struct {
 	UseNextAvailableAddr bool            `json:"use_next_available_address,omitempty"`
 	COV                  float64         `json:"cov,omitempty"`
 	Priority             *model.Priority `json:"priority_array_write,omitempty"`
+}
+
+type NameStruct struct {
+	Type     string `json:"type" default:"string"`
+	Required bool   `json:"required" default:"true"`
+	Min      int    `json:"min" default:"3"`
+	Max      int    `json:"max" default:"20"`
+}
+
+type DescriptionStruct struct {
+	Type     string `json:"type" default:"string"`
+	Required bool   `json:"required" default:"false"`
+	Min      int    `json:"min" default:"0"`
+	Max      int    `json:"max" default:"80"`
+}
+
+type Network struct {
+	Name        NameStruct        `json:"name"`
+	Description DescriptionStruct `json:"description"`
+}
+
+type Device struct {
+	Name        NameStruct        `json:"name"`
+	Description DescriptionStruct `json:"description"`
+}
+
+type Point struct {
+	Name        NameStruct        `json:"name"`
+	Description DescriptionStruct `json:"description"`
+}
+
+func GetNetworkSchema() *Network {
+	network := &Network{}
+	defaults.Set(network)
+	return network
+}
+
+func GetDeviceSchema() *Device {
+	device := &Device{}
+	defaults.Set(device)
+	return device
+}
+
+func GetPointSchema() *Point {
+	point := &Point{}
+	defaults.Set(point)
+	return point
 }

--- a/plugin/nube/protocals/bacnetserver/plgrest/error.go
+++ b/plugin/nube/protocals/bacnetserver/plgrest/error.go
@@ -1,4 +1,4 @@
-package pkgrest
+package plgrest
 
 import (
 	"fmt"
@@ -7,7 +7,7 @@ import (
 
 // An Error maps to Form3 API error responses
 type Error struct {
-	Code    int `json:"error_code,omitempty"`
+	Code    int    `json:"error_code,omitempty"`
 	Message string `json:"error_message,omitempty"`
 }
 
@@ -18,4 +18,3 @@ func getAPIError(resp *resty.Response) error {
 	e.Message = resp.String()
 	return fmt.Errorf("request failed [%d]: %s", e.Code, e.Message)
 }
-

--- a/plugin/nube/protocals/bacnetserver/plgrest/init.go
+++ b/plugin/nube/protocals/bacnetserver/plgrest/init.go
@@ -1,4 +1,4 @@
-package pkgrest
+package plgrest
 
 import (
 	"fmt"
@@ -7,7 +7,7 @@ import (
 
 // RestClient is used to invoke Form3 Accounts API.
 type RestClient struct {
-	client *resty.Client
+	client      *resty.Client
 	ClientToken string
 }
 

--- a/plugin/nube/protocals/bacnetserver/plgrest/methods.go
+++ b/plugin/nube/protocals/bacnetserver/plgrest/methods.go
@@ -1,16 +1,16 @@
-package pkgrest
+package plgrest
 
 import (
 	"fmt"
-	"github.com/NubeDev/flow-framework/model"
-	pkgmodel "github.com/NubeDev/flow-framework/plugin/nube/protocals/bacnetserver/model"
+	baseModel "github.com/NubeDev/flow-framework/model"
+	"github.com/NubeDev/flow-framework/plugin/nube/protocals/bacnetserver/model"
 	"strconv"
 )
 
 // GetPoints all points
-func (a *RestClient) GetPoints() (*[]pkgmodel.BacnetPoint, error) {
+func (a *RestClient) GetPoints() (*[]model.BacnetPoint, error) {
 	resp, err := a.client.R().
-		SetResult([]pkgmodel.BacnetPoint{}).
+		SetResult([]model.BacnetPoint{}).
 		Get("/api/bacnet/points")
 	if err != nil {
 		return nil, fmt.Errorf("fetch name for name %s failed", err)
@@ -18,14 +18,14 @@ func (a *RestClient) GetPoints() (*[]pkgmodel.BacnetPoint, error) {
 	if resp.Error() != nil {
 		return nil, getAPIError(resp)
 	}
-	return resp.Result().(*[]pkgmodel.BacnetPoint), nil
+	return resp.Result().(*[]model.BacnetPoint), nil
 }
 
 // AddPoint an object
-func (a *RestClient) AddPoint(body pkgmodel.BacnetPoint) (*pkgmodel.BacnetPoint, error) {
+func (a *RestClient) AddPoint(body model.BacnetPoint) (*model.BacnetPoint, error) {
 	fmt.Println("ADD POINT ON IN BACNET REST CALL", body)
 	resp, err := a.client.R().
-		SetResult(&pkgmodel.BacnetPoint{}).
+		SetResult(&model.BacnetPoint{}).
 		SetBody(body).
 		Post("/api/bacnet/points")
 	if err != nil {
@@ -34,19 +34,19 @@ func (a *RestClient) AddPoint(body pkgmodel.BacnetPoint) (*pkgmodel.BacnetPoint,
 	if resp.Error() != nil {
 		return nil, getAPIError(resp)
 	}
-	return resp.Result().(*pkgmodel.BacnetPoint), nil
+	return resp.Result().(*model.BacnetPoint), nil
 }
 
 type PriorityWriter struct {
-	PriorityArrayWrite model.Priority `json:"priority_array_write,omitempty"`
+	PriorityArrayWrite baseModel.Priority `json:"priority_array_write,omitempty"`
 }
 
 // EditPoint an object
-func (a *RestClient) EditPoint(body pkgmodel.BacnetPoint, obj string, addr int) (*pkgmodel.BacnetPoint, error) {
+func (a *RestClient) EditPoint(body model.BacnetPoint, obj string, addr int) (*model.BacnetPoint, error) {
 	priorityWriter := new(PriorityWriter)
 	priorityWriter.PriorityArrayWrite = *body.Priority
 	resp, err := a.client.R().
-		SetResult(&pkgmodel.BacnetPoint{}).
+		SetResult(&model.BacnetPoint{}).
 		SetBody(priorityWriter).
 		SetPathParams(map[string]string{"obj": obj, "addr": strconv.Itoa(addr)}).
 		Patch("/api/bacnet/points/obj/{obj}/{addr}")
@@ -56,7 +56,7 @@ func (a *RestClient) EditPoint(body pkgmodel.BacnetPoint, obj string, addr int) 
 	if resp.Error() != nil {
 		return nil, getAPIError(resp)
 	}
-	return resp.Result().(*pkgmodel.BacnetPoint), nil
+	return resp.Result().(*model.BacnetPoint), nil
 }
 
 // DeletePoint an object
@@ -74,9 +74,9 @@ func (a *RestClient) DeletePoint(obj string, addr int) (bool, error) {
 }
 
 // PingServer all points
-func (a *RestClient) PingServer() (*pkgmodel.ServerPing, error) {
+func (a *RestClient) PingServer() (*model.ServerPing, error) {
 	resp, err := a.client.R().
-		SetResult(&pkgmodel.ServerPing{}).
+		SetResult(&model.ServerPing{}).
 		Get("/api/system/ping")
 	if err != nil {
 		return nil, fmt.Errorf("error geting server %s failed", err)
@@ -84,13 +84,13 @@ func (a *RestClient) PingServer() (*pkgmodel.ServerPing, error) {
 	if resp.Error() != nil {
 		return nil, getAPIError(resp)
 	}
-	return resp.Result().(*pkgmodel.ServerPing), nil
+	return resp.Result().(*model.ServerPing), nil
 }
 
 // GetServer all points
-func (a *RestClient) GetServer() (*pkgmodel.Server, error) {
+func (a *RestClient) GetServer() (*model.Server, error) {
 	resp, err := a.client.R().
-		SetResult(&pkgmodel.Server{}).
+		SetResult(&model.Server{}).
 		Get("/api/bacnet/server")
 	if err != nil {
 		return nil, fmt.Errorf("error geting server %s failed", err)
@@ -98,13 +98,13 @@ func (a *RestClient) GetServer() (*pkgmodel.Server, error) {
 	if resp.Error() != nil {
 		return nil, getAPIError(resp)
 	}
-	return resp.Result().(*pkgmodel.Server), nil
+	return resp.Result().(*model.Server), nil
 }
 
 // EditServer an object
-func (a *RestClient) EditServer(body pkgmodel.Server) (*pkgmodel.Server, error) {
+func (a *RestClient) EditServer(body model.Server) (*model.Server, error) {
 	resp, err := a.client.R().
-		SetResult(&pkgmodel.Server{}).
+		SetResult(&model.Server{}).
 		SetBody(body).
 		Patch("/api/bacnet/server")
 	if err != nil {
@@ -113,5 +113,5 @@ func (a *RestClient) EditServer(body pkgmodel.Server) (*pkgmodel.Server, error) 
 	if resp.Error() != nil {
 		return nil, getAPIError(resp)
 	}
-	return resp.Result().(*pkgmodel.Server), nil
+	return resp.Result().(*model.Server), nil
 }

--- a/plugin/nube/protocals/edge28/enable.go
+++ b/plugin/nube/protocals/edge28/enable.go
@@ -9,9 +9,7 @@ import (
 func (i *Instance) Enable() error {
 	i.enabled = true
 	i.setUUID()
-	var arg api.Args
-	arg.WithIpConnection = true
-	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, arg)
+	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, api.Args{})
 	if q != nil {
 		i.networkUUID = q.UUID
 	} else {

--- a/plugin/nube/protocals/edge28/polling.go
+++ b/plugin/nube/protocals/edge28/polling.go
@@ -101,8 +101,6 @@ func (i *Instance) polling(p polling) error {
 	var arg api.Args
 	arg.WithDevices = true
 	arg.WithPoints = true
-	arg.WithSerialConnection = true
-	arg.WithIpConnection = true
 	f := func() (bool, error) {
 		nets, err := i.db.GetNetworksByPlugin(i.pluginUUID, arg)
 		if err != nil {

--- a/plugin/nube/protocals/lora/api.go
+++ b/plugin/nube/protocals/lora/api.go
@@ -72,4 +72,11 @@ func (i *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 		ctx.JSON(http.StatusOK, serial_model.GetNetworkSchema())
 	})
 
+	mux.GET(schemaDevice, func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, serial_model.GetDeviceSchema())
+	})
+
+	mux.GET(schemaPoint, func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, serial_model.GetPointSchema())
+	})
 }

--- a/plugin/nube/protocals/lora/api.go
+++ b/plugin/nube/protocals/lora/api.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	serial_model "github.com/NubeDev/flow-framework/plugin/nube/protocals/lora/model"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
 
 const (
-	help          = "/lora/help"
-	restartSerial = "/lora/serial/restart"
-	listSerial    = "/lora/serial/list"
-	wizardSerial  = "/lora/wizard/serial"
+	help          = "/help"
+	restartSerial = "/serial/restart"
+	listSerial    = "/serial/list"
+	wizardSerial  = "/wizard/serial"
+	schemaNetwork = "/schema/network"
+	schemaDevice  = "/schema/device"
+	schemaPoint   = "/schema/point"
 )
 
 // wizard
@@ -63,6 +67,9 @@ func (i *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 		} else {
 			ctx.JSON(http.StatusOK, serial)
 		}
+	})
+	mux.GET(schemaNetwork, func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, serial_model.GetNetworkSchema())
 	})
 
 }

--- a/plugin/nube/protocals/lora/api.go
+++ b/plugin/nube/protocals/lora/api.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	serial_model "github.com/NubeDev/flow-framework/plugin/nube/protocals/lora/model"
+	"github.com/NubeDev/flow-framework/plugin/nube/protocals/lora/model"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
@@ -69,14 +69,14 @@ func (i *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 		}
 	})
 	mux.GET(schemaNetwork, func(ctx *gin.Context) {
-		ctx.JSON(http.StatusOK, serial_model.GetNetworkSchema())
+		ctx.JSON(http.StatusOK, model.GetNetworkSchema())
 	})
 
 	mux.GET(schemaDevice, func(ctx *gin.Context) {
-		ctx.JSON(http.StatusOK, serial_model.GetDeviceSchema())
+		ctx.JSON(http.StatusOK, model.GetDeviceSchema())
 	})
 
 	mux.GET(schemaPoint, func(ctx *gin.Context) {
-		ctx.JSON(http.StatusOK, serial_model.GetPointSchema())
+		ctx.JSON(http.StatusOK, model.GetPointSchema())
 	})
 }

--- a/plugin/nube/protocals/lora/enable.go
+++ b/plugin/nube/protocals/lora/enable.go
@@ -10,9 +10,7 @@ func (i *Instance) Enable() error {
 	i.enabled = true
 	i.setUUID()
 	i.BusServ()
-	var arg api.Args
-	arg.WithSerialConnection = true
-	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, arg)
+	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, api.Args{})
 	if q != nil {
 		i.networkUUID = q.UUID
 	} else {

--- a/plugin/nube/protocals/lora/main.go
+++ b/plugin/nube/protocals/lora/main.go
@@ -43,6 +43,7 @@ func GetFlowPluginInfo() plugin.Info {
 		Description:  description,
 		Author:       author,
 		Website:      webSite,
+		HasNetwork:   true,
 		ProtocolType: protocolType,
 	}
 }

--- a/plugin/nube/protocals/lora/model/serial.go
+++ b/plugin/nube/protocals/lora/model/serial.go
@@ -26,6 +26,17 @@ type DescriptionStruct struct {
 	Max      int    `json:"max" default:"80"`
 }
 
+type TransportTypeStruct struct {
+	Type     string `json:"type" default:"string"`
+	Required bool   `json:"required" default:"true"`
+	Default  string `json:"default" default:"serial"`
+}
+
+type EnableStruct struct {
+	Type     string `json:"type" default:"bool"`
+	Required bool   `json:"required" default:"false"`
+}
+
 type Network struct {
 	Name        NameStruct        `json:"name"`
 	Description DescriptionStruct `json:"description"`
@@ -34,12 +45,8 @@ type Network struct {
 		Required bool   `json:"required" default:"true"`
 		Default  string `json:"default" default:"lora"`
 	} `json:"plugin_name"`
-	TransportType struct {
-		Type     string `json:"type" default:"string"`
-		Required bool   `json:"required" default:"true"`
-		Default  string `json:"default" default:"serial"`
-	} `json:"transport_type"`
-	SerialPort struct {
+	TransportType TransportTypeStruct `json:"transport_type"`
+	SerialPort    struct {
 		Type     string `json:"type" default:"string"`
 		Required bool   `json:"required" default:"true"`
 		Min      int    `json:"min" default:"3"`
@@ -52,8 +59,54 @@ type Network struct {
 	} `json:"baud_rate"`
 }
 
+type Device struct {
+	Name          NameStruct          `json:"name"`
+	Description   DescriptionStruct   `json:"description"`
+	Enable        EnableStruct        `json:"enable"`
+	TransportType TransportTypeStruct `json:"transport_type"`
+}
+
+type Point struct {
+	Name        NameStruct        `json:"name"`
+	Description DescriptionStruct `json:"description"`
+	Address     struct {
+		Type     string `json:"type" default:"string"`
+		Required bool   `json:"required" default:"true"`
+		Min      int    `json:"min" default:"8"`
+		Max      int    `json:"max" default:"8"`
+	} `json:"address"`
+	IoId struct {
+		Type     string `json:"type" default:"string"`
+		Required bool   `json:"required" default:"true"`
+		Min      int    `json:"min" default:"3"`
+		Max      int    `json:"max" default:"20"`
+	} `json:"io_id"`
+	ThingClass struct {
+		Type     string   `json:"type" default:"array"`
+		Required bool     `json:"required" default:"true"`
+		Options  []string `json:"options" default:"[\"point\"]"`
+	} `json:"thing_class"`
+	ThingType struct {
+		Type     string   `json:"type" default:"array"`
+		Required bool     `json:"required" default:"true"`
+		Options  []string `json:"options" default:"[\"point\"]"`
+	} `json:"thing_type"`
+}
+
 func GetNetworkSchema() *Network {
 	network := &Network{}
 	defaults.Set(network)
 	return network
+}
+
+func GetDeviceSchema() *Device {
+	device := &Device{}
+	defaults.Set(device)
+	return device
+}
+
+func GetPointSchema() *Point {
+	point := &Point{}
+	defaults.Set(point)
+	return point
 }

--- a/plugin/nube/protocals/lora/model/serial.go
+++ b/plugin/nube/protocals/lora/model/serial.go
@@ -1,6 +1,7 @@
 package serial_model
 
 import (
+	"github.com/NubeDev/flow-framework/plugin/defaults"
 	"github.com/NubeDev/flow-framework/plugin/plugin-api"
 )
 
@@ -9,4 +10,56 @@ type Message struct {
 	Msg         plugin.Message
 	ChannelName string
 	IsSend      bool
+}
+
+type NameStruct struct {
+	Type     string `json:"type" default:"string"`
+	Required bool   `json:"required" default:"true"`
+	Min      int    `json:"min" default:"3"`
+	Max      int    `json:"max" default:"20"`
+}
+
+type DescriptionStruct struct {
+	Type     string `json:"type" default:"string"`
+	Required bool   `json:"required" default:"false"`
+	Min      int    `json:"min" default:"0"`
+	Max      int    `json:"max" default:"80"`
+}
+
+type Network struct {
+	Name        NameStruct        `json:"name"`
+	Description DescriptionStruct `json:"description"`
+	PluginName  struct {
+		Type     string `json:"type" default:"string"`
+		Required bool   `json:"required" default:"true"`
+		Default  string `json:"default" default:"lora"`
+	} `json:"plugin_name"`
+	TransportType struct {
+		Type     string `json:"type" default:"string"`
+		Required bool   `json:"required" default:"true"`
+		Default  string `json:"default" default:"serial"`
+	} `json:"transport_type"`
+	SerialConnection struct {
+		Type     string `json:"type" default:"object"`
+		Required bool   `json:"required" default:"true"`
+		Object   struct {
+			SerialPort struct {
+				Type     string `json:"type" default:"string"`
+				Required bool   `json:"required" default:"true"`
+				Min      int    `json:"min" default:"3"`
+				Max      int    `json:"max" default:"20"`
+			} `json:"serial_port"`
+			BaudRate struct {
+				Type     string `json:"type" default:"int"`
+				Required bool   `json:"required" default:"true"`
+				Default  int    `json:"default" default:"9600"`
+			} `json:"baud_rate"`
+		} `json:"object"`
+	} `json:"serial_connection"`
+}
+
+func GetNetworkSchema() *Network {
+	network := &Network{}
+	defaults.Set(network)
+	return network
 }

--- a/plugin/nube/protocals/lora/model/serial.go
+++ b/plugin/nube/protocals/lora/model/serial.go
@@ -1,16 +1,8 @@
-package serial_model
+package model
 
 import (
 	"github.com/NubeDev/flow-framework/plugin/defaults"
-	"github.com/NubeDev/flow-framework/plugin/plugin-api"
 )
-
-// Message is a message wrapper with the channel, sender and recipient.
-type Message struct {
-	Msg         plugin.Message
-	ChannelName string
-	IsSend      bool
-}
 
 type NameStruct struct {
 	Type     string `json:"type" default:"string"`

--- a/plugin/nube/protocals/lora/model/serial.go
+++ b/plugin/nube/protocals/lora/model/serial.go
@@ -39,23 +39,17 @@ type Network struct {
 		Required bool   `json:"required" default:"true"`
 		Default  string `json:"default" default:"serial"`
 	} `json:"transport_type"`
-	SerialConnection struct {
-		Type     string `json:"type" default:"object"`
+	SerialPort struct {
+		Type     string `json:"type" default:"string"`
 		Required bool   `json:"required" default:"true"`
-		Object   struct {
-			SerialPort struct {
-				Type     string `json:"type" default:"string"`
-				Required bool   `json:"required" default:"true"`
-				Min      int    `json:"min" default:"3"`
-				Max      int    `json:"max" default:"20"`
-			} `json:"serial_port"`
-			BaudRate struct {
-				Type     string `json:"type" default:"int"`
-				Required bool   `json:"required" default:"true"`
-				Default  int    `json:"default" default:"9600"`
-			} `json:"baud_rate"`
-		} `json:"object"`
-	} `json:"serial_connection"`
+		Min      int    `json:"min" default:"3"`
+		Max      int    `json:"max" default:"20"`
+	} `json:"serial_port"`
+	BaudRate struct {
+		Type     string `json:"type" default:"int"`
+		Required bool   `json:"required" default:"true"`
+		Default  int    `json:"default" default:"9600"`
+	} `json:"baud_rate"`
 }
 
 func GetNetworkSchema() *Network {

--- a/plugin/nube/protocals/lora/serial.go
+++ b/plugin/nube/protocals/lora/serial.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-
 	"github.com/NubeDev/flow-framework/api"
 	"github.com/NubeDev/flow-framework/plugin/nube/protocals/lora/decoder"
 	log "github.com/sirupsen/logrus"
@@ -23,20 +22,18 @@ type SerialSetting struct {
 	I              Instance
 }
 
-// SerialOpen open serial port
 func (i *Instance) SerialOpen() error {
 	s := new(SerialSetting)
 	var arg api.Args
-	arg.WithSerialConnection = true
 	net, err := i.db.GetNetworkByPlugin(i.pluginUUID, arg)
 	if err != nil {
 		return err
 	}
-	if net.SerialConnection == nil {
+	if net.SerialPort == nil || net.SerialBaudRate == nil {
 		return err
 	}
-	s.SerialPort = net.SerialConnection.SerialPort
-	s.BaudRate = int(net.SerialConnection.BaudRate)
+	s.SerialPort = *net.SerialPort
+	s.BaudRate = int(*net.SerialBaudRate)
 	connected := false
 	go func() error {
 		sc := New(s)
@@ -51,7 +48,6 @@ func (i *Instance) SerialOpen() error {
 
 }
 
-// SerialClose close serial port
 func (i *Instance) SerialClose() error {
 	err := Disconnect()
 	if err != nil {

--- a/plugin/nube/protocals/lora/utils.go
+++ b/plugin/nube/protocals/lora/utils.go
@@ -22,15 +22,12 @@ func (i *Instance) wizardSerial(body wizard) (string, error) {
 	if body.SensorType != "" {
 		st = body.SensorType
 	}
-	var ser model.SerialConnection
-	ser.SerialPort = sp
-	ser.BaudRate = 38400
-
 	var net model.Network
 	net.Name = model.TransProtocol.Lora
 	net.TransportType = model.TransType.Serial
 	net.PluginPath = model.TransProtocol.Lora
-	net.SerialConnection = &ser
+	net.SerialPort = utils.NewStringAddress(sp)
+	net.SerialBaudRate = utils.NewUint(38400)
 
 	var dev model.Device
 	dev.Name = model.TransProtocol.Lora

--- a/plugin/nube/protocals/lorawan/app.go
+++ b/plugin/nube/protocals/lorawan/app.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/NubeDev/flow-framework/model"
-	"github.com/NubeDev/flow-framework/plugin/nube/protocals/bacnetserver/model"
-	lwmodel "github.com/NubeDev/flow-framework/plugin/nube/protocals/lorawan/model"
+	baseModel "github.com/NubeDev/flow-framework/model"
+	bacnetServerModel "github.com/NubeDev/flow-framework/plugin/nube/protocals/bacnetserver/model"
+	model "github.com/NubeDev/flow-framework/plugin/nube/protocals/lorawan/model"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
@@ -13,12 +13,12 @@ const (
 )
 
 //mqttUpdate listen on mqtt and then update the point in flow-framework
-func (i *Instance) mqttUpdate(body mqtt.Message, devEUI, appID string) (*model.Point, error) {
+func (i *Instance) mqttUpdate(body mqtt.Message, devEUI, appID string) (*baseModel.Point, error) {
 	//do an api call to chirpstack to get the device profile
 	//decode the mqtt payload based of the device profile
 	//if deviceProfileName
 
-	payload := new(lwmodel.BasePayload)
+	payload := new(model.BasePayload)
 	err := json.Unmarshal(body.Payload(), &payload)
 
 	dev, err := i.REST.GetDevice(payload.DevEUI)
@@ -27,7 +27,7 @@ func (i *Instance) mqttUpdate(body mqtt.Message, devEUI, appID string) (*model.P
 	}
 	//check the payload for how to decode from
 	if dev.Device.DeviceProfileID == elsysAPB {
-		decoded := new(lwmodel.ElsysAPB)
+		decoded := new(model.ElsysAPB)
 		err = json.Unmarshal(body.Payload(), &decoded)
 	}
 	if err != nil {
@@ -38,19 +38,17 @@ func (i *Instance) mqttUpdate(body mqtt.Message, devEUI, appID string) (*model.P
 }
 
 //addPoint from rest api
-func (i *Instance) addPoint(body *model.Point) (*model.Point, error) {
+func (i *Instance) addPoint(body *baseModel.Point) (*baseModel.Point, error) {
 	return nil, nil
-
 }
 
 //pointPatch from rest
-func (i *Instance) pointPatch(body *model.Point) (*model.Point, error) {
+func (i *Instance) pointPatch(body *baseModel.Point) (*baseModel.Point, error) {
 	return nil, nil
-
 }
 
 //delete point make sure
-func (i *Instance) deletePoint(body *model.Point) (bool, error) {
+func (i *Instance) deletePoint(body *baseModel.Point) (bool, error) {
 	return true, nil
 }
 
@@ -71,6 +69,6 @@ func (i *Instance) DropDevices() (bool, error) {
 }
 
 //delete point make sure
-func (i *Instance) serverDeletePoint(body *pkgmodel.BacnetPoint) (bool, error) {
+func (i *Instance) serverDeletePoint(body *bacnetServerModel.BacnetPoint) (bool, error) {
 	return true, nil
 }

--- a/plugin/nube/protocals/lorawan/enable.go
+++ b/plugin/nube/protocals/lorawan/enable.go
@@ -11,9 +11,7 @@ func (i *Instance) Enable() error {
 	i.enabled = true
 	i.setUUID()
 	i.BusServ()
-	var arg api.Args
-	arg.WithIpConnection = true
-	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, arg)
+	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, api.Args{})
 	if q != nil {
 		i.networkUUID = q.UUID
 	} else {

--- a/plugin/nube/protocals/modbus/api.go
+++ b/plugin/nube/protocals/modbus/api.go
@@ -1,11 +1,20 @@
 package main
 
 import (
-	"github.com/NubeDev/flow-framework/model"
+	baseModel "github.com/NubeDev/flow-framework/model"
+	"github.com/NubeDev/flow-framework/plugin/nube/protocals/modbus/model"
 	"github.com/NubeDev/flow-framework/utils"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 	"net/http"
+)
+
+const (
+	help          = "/help"
+	listSerial    = "/list/serial"
+	schemaNetwork = "/schema/network"
+	schemaDevice  = "/schema/device"
+	schemaPoint   = "/schema/point"
 )
 
 type Scan struct {
@@ -61,31 +70,26 @@ type T2 struct {
 //supportedObjects return all objects that are not bacnet
 func supportedObjects() *utils.Array {
 	out := utils.NewArray()
-	objs := utils.ArrayValues(model.ObjectTypes)
+	objs := utils.ArrayValues(baseModel.ObjectTypes)
 	for _, obj := range objs {
 		switch obj {
-		case model.ObjectTypes.AnalogInput:
+		case baseModel.ObjectTypes.AnalogInput:
 			out.Add(obj)
-		case model.ObjectTypes.AnalogOutput:
+		case baseModel.ObjectTypes.AnalogOutput:
 			out.Add(obj)
-		case model.ObjectTypes.AnalogValue:
+		case baseModel.ObjectTypes.AnalogValue:
 			out.Add(obj)
-		case model.ObjectTypes.BinaryInput:
+		case baseModel.ObjectTypes.BinaryInput:
 			out.Add(obj)
-		case model.ObjectTypes.BinaryOutput:
+		case baseModel.ObjectTypes.BinaryOutput:
 			out.Add(obj)
-		case model.ObjectTypes.BinaryValue:
+		case baseModel.ObjectTypes.BinaryValue:
 			out.Add(obj)
 		default:
 		}
 	}
 	return out
 }
-
-const (
-	help       = "/modbus/help"
-	listSerial = "/modbus/list/serial"
-)
 
 // RegisterWebhook implements plugin.Webhooker
 func (i *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
@@ -184,4 +188,15 @@ func (i *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 		}
 	})
 
+	mux.GET(schemaNetwork, func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, model.GetNetworkSchema())
+	})
+
+	mux.GET(schemaDevice, func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, model.GetDeviceSchema())
+	})
+
+	mux.GET(schemaPoint, func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, model.GetPointSchema())
+	})
 }

--- a/plugin/nube/protocals/modbus/app.go
+++ b/plugin/nube/protocals/modbus/app.go
@@ -67,7 +67,6 @@ func (i *Instance) wizardTCP(body wizard) (string, error) {
 //wizard make a network/dev/pnt
 func (i *Instance) wizardSerial(body wizard) (string, error) {
 
-	var s model.SerialConnection
 	sp := "/dev/ttyUSB0"
 	if body.SerialPort != "" {
 		sp = body.SerialPort
@@ -76,14 +75,13 @@ func (i *Instance) wizardSerial(body wizard) (string, error) {
 	if body.BaudRate != 0 {
 		br = int(body.BaudRate)
 	}
-	s.SerialPort = sp
-	s.BaudRate = uint(br)
 
 	var net model.Network
 	net.Name = "modbus"
 	net.TransportType = model.TransType.Serial
 	net.PluginPath = "modbus"
-	net.SerialConnection = &s
+	net.SerialPort = &sp
+	net.SerialBaudRate = utils.NewUint(uint(br))
 
 	da := 1
 	if body.DeviceAddr != 0 {

--- a/plugin/nube/protocals/modbus/enable.go
+++ b/plugin/nube/protocals/modbus/enable.go
@@ -11,9 +11,7 @@ func (i *Instance) Enable() error {
 	i.enabled = true
 	i.setUUID()
 	i.BusServ()
-	var arg api.Args
-	arg.WithIpConnection = true
-	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, arg)
+	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, api.Args{})
 	if q != nil {
 		i.networkUUID = q.UUID
 	} else {
@@ -56,6 +54,5 @@ func (i *Instance) Disable() error {
 			return errors.New("error on starting polling")
 		}
 	}
-
 	return nil
 }

--- a/plugin/nube/protocals/modbus/main.go
+++ b/plugin/nube/protocals/modbus/main.go
@@ -44,6 +44,7 @@ func GetFlowPluginInfo() plugin.Info {
 		Description:  description,
 		Author:       author,
 		Website:      webSite,
+		HasNetwork:   true,
 		ProtocolType: protocolType,
 	}
 }

--- a/plugin/nube/protocals/modbus/model/model.go
+++ b/plugin/nube/protocals/modbus/model/model.go
@@ -1,6 +1,7 @@
-package modmodel
+package model
 
 import (
+	"github.com/NubeDev/flow-framework/plugin/defaults"
 	"github.com/NubeIO/null"
 )
 
@@ -21,5 +22,51 @@ type Priority struct {
 	P14 null.Float `json:"_14,omitempty"`
 	P15 null.Float `json:"_15,omitempty"`
 	P16 null.Float `json:"_16"` //removed and added to the point to save one DB write
+}
 
+type NameStruct struct {
+	Type     string `json:"type" default:"string"`
+	Required bool   `json:"required" default:"true"`
+	Min      int    `json:"min" default:"3"`
+	Max      int    `json:"max" default:"20"`
+}
+
+type DescriptionStruct struct {
+	Type     string `json:"type" default:"string"`
+	Required bool   `json:"required" default:"false"`
+	Min      int    `json:"min" default:"0"`
+	Max      int    `json:"max" default:"80"`
+}
+
+type Network struct {
+	Name        NameStruct        `json:"name"`
+	Description DescriptionStruct `json:"description"`
+}
+
+type Device struct {
+	Name        NameStruct        `json:"name"`
+	Description DescriptionStruct `json:"description"`
+}
+
+type Point struct {
+	Name        NameStruct        `json:"name"`
+	Description DescriptionStruct `json:"description"`
+}
+
+func GetNetworkSchema() *Network {
+	network := &Network{}
+	defaults.Set(network)
+	return network
+}
+
+func GetDeviceSchema() *Device {
+	device := &Device{}
+	defaults.Set(device)
+	return device
+}
+
+func GetPointSchema() *Point {
+	point := &Point{}
+	defaults.Set(point)
+	return point
 }

--- a/plugin/nube/protocals/modbus/polling.go
+++ b/plugin/nube/protocals/modbus/polling.go
@@ -63,8 +63,6 @@ func (i *Instance) PollingTCP(p polling) error {
 	var arg api.Args
 	arg.WithDevices = true
 	arg.WithPoints = true
-	arg.WithSerialConnection = true
-	arg.WithIpConnection = true
 	f := func() (bool, error) {
 		nets, err := i.db.GetNetworksByPlugin(i.pluginUUID, arg)
 		if err != nil {
@@ -83,10 +81,13 @@ func (i *Instance) PollingTCP(p polling) error {
 					var dCheck devCheck
 					dCheck.devUUID = dev.UUID
 					if net.TransportType == model.TransType.Serial {
-						client.SerialPort = net.SerialConnection.SerialPort
-						client.BaudRate = net.SerialConnection.BaudRate
-						client.DataBits = net.SerialConnection.DataBits
-						client.StopBits = net.SerialConnection.StopBits
+						if net.SerialPort != nil || net.SerialBaudRate != nil || net.SerialDataBits != nil || net.SerialStopBits != nil {
+							return true, errors.New("no serial connection details")
+						}
+						client.SerialPort = *net.SerialPort
+						client.BaudRate = *net.SerialBaudRate
+						client.DataBits = *net.SerialDataBits
+						client.StopBits = *net.SerialStopBits
 						err = i.setClient(client, net.UUID, true, true)
 						if err != nil {
 							log.Errorf("modbus: failed to set client %v %s\n", err, dev.CommonIP.Host)

--- a/plugin/nube/protocals/rubix/enable.go
+++ b/plugin/nube/protocals/rubix/enable.go
@@ -10,9 +10,7 @@ import (
 func (i *Instance) Enable() error {
 	i.enabled = true
 	i.setUUID()
-	var arg api.Args
-	arg.WithIpConnection = true
-	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, arg)
+	q, err := i.db.GetNetworkByPlugin(i.pluginUUID, api.Args{})
 	if q != nil {
 		i.networkUUID = q.UUID
 	} else {

--- a/plugin/nube/system/api.go
+++ b/plugin/nube/system/api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/NubeDev/flow-framework/model"
+	system_model "github.com/NubeDev/flow-framework/plugin/nube/system/model"
 	"github.com/NubeDev/flow-framework/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/gomarkdown/markdown"
@@ -40,14 +41,6 @@ You will never use anything else than this [website].
 - [ ] Contact the media
 
 this is *some* normal texy`
-
-type Point struct {
-	ObjectType struct {
-		Options  interface{} `json:"options"`
-		Type     string      `json:"type"`
-		Required bool        `json:"required"`
-	} `json:"object_type"`
-}
 
 //supportedObjects return all objects that are not bacnet
 func supportedObjects() *utils.Array {
@@ -99,12 +92,8 @@ func (i *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 		ctx.Writer.Write(output)
 	})
 	mux.GET(schemaPoint, func(ctx *gin.Context) {
-		var h Point
-		h.ObjectType.Options = supportedObjects()
-		h.ObjectType.Type = "array"
-		h.ObjectType.Required = true
-		ctx.JSON(http.StatusOK, h)
-
+		point := system_model.GetPointSchema()
+		ctx.JSON(http.StatusOK, point)
 	})
 	mux.GET("/system/schedule/store/:name", func(ctx *gin.Context) {
 		obj, ok := i.store.Get(resolveName(ctx))

--- a/plugin/nube/system/model/model.go
+++ b/plugin/nube/system/model/model.go
@@ -1,14 +1,19 @@
-package model
+package system_model
 
 import (
-	"github.com/NubeDev/flow-framework/plugin/plugin-api"
+	"github.com/NubeDev/flow-framework/plugin/defaults"
 )
 
-// Message is a message wrapper with the channel, sender and recipient.
-type Message struct {
-	Sender      plugin.UserContext
-	Receiver    plugin.UserContext
-	Msg         plugin.Message
-	ChannelName string
-	IsSend      bool
+type Point struct {
+	ObjectType struct {
+		Options  []string `json:"options" default:"[\"analogInput\",\"analogOutput\",\"analogValue\",\"binaryInput\",\"binaryOutput\",\"binaryValue\"]"`
+		Type     string   `json:"type" default:"array"`
+		Required bool     `json:"required" default:"true"`
+	} `json:"object_type"`
+}
+
+func GetPointSchema() *Point {
+	point := &Point{}
+	defaults.Set(point)
+	return point
 }

--- a/plugin/nube/utils/backup/app.go
+++ b/plugin/nube/utils/backup/app.go
@@ -100,8 +100,6 @@ func (i *Instance) backNetworks() error {
 	var arg api.Args
 	arg.WithDevices = true
 	arg.WithPoints = true
-	arg.WithSerialConnection = true
-	arg.WithIpConnection = true
 
 	nets, err := i.db.GetNetworks(arg)
 	if err != nil {

--- a/plugin/plugin-api/plugin.go
+++ b/plugin/plugin-api/plugin.go
@@ -19,5 +19,6 @@ type Info struct {
 	Description  string
 	License      string
 	ModulePath   string
+	HasNetwork   bool
 	ProtocolType string
 }

--- a/router/router.go
+++ b/router/router.go
@@ -107,7 +107,7 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 	dbGroup.SyncTopics()
 	//for the custom plugin endpoints you need to use the plugin token
 	//http://0.0.0.0:1660/plugins/api/UUID/PLUGIN_TOKEN/echo
-	pluginManager, err := plugin.NewManager(db, conf.GetAbsPluginDir(), engine.Group("/api/plugins/api/:uuid"), streamHandler)
+	pluginManager, err := plugin.NewManager(db, conf.GetAbsPluginDir(), engine.Group("/api/plugins/api"), streamHandler)
 	if err != nil {
 		fmt.Println(err)
 		panic(err)

--- a/utils/nums.go
+++ b/utils/nums.go
@@ -14,6 +14,10 @@ func Float64IsNil(b *float64) float64 {
 	}
 }
 
+func NewUint(value uint) *uint {
+	return &value
+}
+
 func NewInt(value int) *int {
 	return &value
 }


### PR DESCRIPTION
Resolves: #291 

### Summary

- Add `has_network` attributes on plugins (list out `has_network=true` plugins for writing networks, devices, points values)
- Shorten the router length of plugin (`/api/plugins/api/: module_path/<module_path>/*` to `/api/plugins/api/:module_path/*`)
- Make flat fields: remove `IpConnection` & `SerialConnection` from network
   - was hard to fit it on the table for display all generic values, easy for frontend
   - as we omit field value on nullability, it won't have large data as well
- Fix: plugins installation
- Minimal schema for LoRa network, device, point
- Skeleton schema for BACnetServer & Modbus


### Endpoints for schema
#### Template

- http://localhost:1660/api/plugins/api/:module_path/schema/:model

Here:
- ** module_path**: comes from http://localhost:1660/api/plugins path attribute where `has_network=true`
- **model**: network|device|point

#### Examples
- http://localhost:1660/api/plugins/api/lora/schema/network
- http://localhost:1660/api/plugins/api/lora/schema/device
- http://localhost:1660/api/plugins/api/lora/schema/point
- http://localhost:1660/api/plugins/api/bacnetserver/schema/point
- http://localhost:1660/api/plugins/api/modbus/schema/point


#### Example of schema

```JSON
{
  "name": {
    "type": "string",
    "required": true,
    "min": 3,
    "max": 20
  },
  "description": {
    "type": "string",
    "required": false,
    "min": 0,
    "max": 80
  },
  "plugin_name": {
    "type": "string",
    "required": true,
    "default": "lora"
  },
  "transport_type": {
    "type": "string",
    "required": true,
    "default": "serial"
  },
  "serial_port": {
    "type": "string",
    "required": true,
    "min": 3,
    "max": 20
  },
  "baud_rate": {
    "type": "int",
    "required": true,
    "default": 9600
  }
}
```