### PR TITLE
Improvements on schedule

### DIFF
--- a/database/producerHistory.go
+++ b/database/producerHistory.go
@@ -133,9 +133,9 @@ func (d *GormDatabase) CreateProducerHistory(history *model.ProducerHistory) (bo
 		priority := new(model.Priority)
 		_ = json.Unmarshal(history.DataStore, &priority)
 		highestPriorityValue := priority.GetHighestPriorityValue()
+		d.DB.Model(&model.Priority{}).Where("point_uuid = ?", producer.ProducerThingUUID).Updates(priority)
 		d.DB.Model(&model.Point{}).Where("uuid = ?", producer.ProducerThingUUID).
 			Updates(map[string]interface{}{
-				"priority":       &priority,
 				"present_value":  highestPriorityValue,
 				"original_value": highestPriorityValue,
 			})

--- a/database/producerHistory.go
+++ b/database/producerHistory.go
@@ -135,19 +135,14 @@ func (d *GormDatabase) CreateProducerHistory(history *model.ProducerHistory) (bo
 		highestPriorityValue := priority.GetHighestPriorityValue()
 		d.DB.Model(&model.Point{}).Where("uuid = ?", producer.ProducerThingUUID).
 			Updates(map[string]interface{}{
+				"priority":       &priority,
 				"present_value":  highestPriorityValue,
 				"original_value": highestPriorityValue,
 			})
 	} else {
-		scheduleWriter := new(model.ScheduleWriterBody)
-		_ = json.Unmarshal(history.DataStore, &scheduleWriter)
-		schedules, err := json.Marshal(scheduleWriter.Schedules)
-		if err != nil {
-			return false, err
-		}
 		d.DB.Model(&model.Schedule{}).Where("uuid = ?", producer.ProducerThingUUID).
 			Updates(map[string]interface{}{
-				"schedules": &schedules,
+				"schedule": &history.DataStore,
 			})
 	}
 	return true, nil

--- a/database/schedule.go
+++ b/database/schedule.go
@@ -44,7 +44,7 @@ func (d *GormDatabase) CreateSchedule(body *model.Schedule) (*model.Schedule, er
 	if err != nil {
 		return nil, err
 	}
-	body.Schedules = validSchedule
+	body.Schedule = validSchedule
 	if err := d.DB.Create(&body).Error; err != nil {
 		return nil, err
 	}
@@ -52,12 +52,12 @@ func (d *GormDatabase) CreateSchedule(body *model.Schedule) (*model.Schedule, er
 }
 
 func (d *GormDatabase) validateSchedule(schedule *model.Schedule) ([]byte, error) {
-	scheduleModel := new(model.Schedules)
-	err := json.Unmarshal(schedule.Schedules, &scheduleModel)
+	scheduleDataModel := new(model.ScheduleData)
+	err := json.Unmarshal(schedule.Schedule, &scheduleDataModel)
 	if err != nil {
 		return nil, err
 	}
-	validSchedule, err := json.Marshal(scheduleModel)
+	validSchedule, err := json.Marshal(scheduleDataModel)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (d *GormDatabase) UpdateSchedule(uuid string, body *model.Schedule) (*model
 	if err != nil {
 		return nil, err
 	}
-	body.Schedules = validSchedule
+	body.Schedule = validSchedule
 	body.ThingClass = model.ThingClass.Schedule
 	body.ThingType = model.ThingClass.Schedule
 	query := d.DB.Where("uuid = ?", uuid).Find(&scheduleModel)

--- a/database/schedule.go
+++ b/database/schedule.go
@@ -52,6 +52,9 @@ func (d *GormDatabase) CreateSchedule(body *model.Schedule) (*model.Schedule, er
 }
 
 func (d *GormDatabase) validateSchedule(schedule *model.Schedule) ([]byte, error) {
+	if schedule.Schedule == nil {
+		return nil, nil
+	}
 	scheduleDataModel := new(model.ScheduleData)
 	err := json.Unmarshal(schedule.Schedule, &scheduleDataModel)
 	if err != nil {

--- a/database/writer.go
+++ b/database/writer.go
@@ -168,19 +168,14 @@ func (d *GormDatabase) WriterAction(uuid string, body *model.WriterBody) (*model
 			highestPriorityValue := priority.GetHighestPriorityValue()
 			d.DB.Model(&model.Point{}).Where("uuid = ?", writer.WriterThingUUID).
 				Updates(map[string]interface{}{
+					"priority":       &priority,
 					"present_value":  highestPriorityValue,
 					"original_value": highestPriorityValue,
 				})
 		} else if writer.WriterThingClass == model.ThingClass.Schedule {
-			scheduleWriter := new(model.ScheduleWriterBody)
-			_ = json.Unmarshal(writer.DataStore, &scheduleWriter)
-			schedules, err := json.Marshal(scheduleWriter.Schedules)
-			if err != nil {
-				return nil, err
-			}
 			d.DB.Model(&model.Schedule{}).Where("uuid = ?", writer.WriterThingUUID).
 				Updates(map[string]interface{}{
-					"schedules": &schedules,
+					"schedule": &writer.DataStore,
 				})
 		}
 		d.DB.Model(&writer).Updates(writer)

--- a/database/writer.go
+++ b/database/writer.go
@@ -166,9 +166,9 @@ func (d *GormDatabase) WriterAction(uuid string, body *model.WriterBody) (*model
 			priority := new(model.Priority)
 			_ = json.Unmarshal(writer.DataStore, &priority)
 			highestPriorityValue := priority.GetHighestPriorityValue()
+			d.DB.Model(&model.Priority{}).Where("point_uuid = ?", writer.WriterThingUUID).Updates(priority)
 			d.DB.Model(&model.Point{}).Where("uuid = ?", writer.WriterThingUUID).
 				Updates(map[string]interface{}{
-					"priority":       &priority,
 					"present_value":  highestPriorityValue,
 					"original_value": highestPriorityValue,
 				})

--- a/model/schedule.go
+++ b/model/schedule.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"gorm.io/datatypes"
-	"time"
 )
 
 type Schedule struct {
@@ -31,8 +30,8 @@ type Schedules struct {
 type Events struct {
 	Name  string `json:"name"`
 	Dates []struct {
-		Start time.Time `json:"start"`
-		End   time.Time `json:"end"`
+		Start string `json:"start"`
+		End   string `json:"end"`
 	} `json:"dates"`
 	Value int    `json:"value"`
 	Color string `json:"color"`
@@ -48,9 +47,11 @@ type Weekly struct {
 }
 
 type Exception struct {
-	Id    string `json:"id"`
 	Name  string `json:"name"`
-	Color string `json:"color"`
-	Date  string `json:"date"`
+	Dates []struct {
+		Start string `json:"start"`
+		End   string `json:"end"`
+	} `json:"dates"`
 	Value int    `json:"value"`
+	Color string `json:"color"`
 }

--- a/model/schedule.go
+++ b/model/schedule.go
@@ -11,10 +11,15 @@ type Schedule struct {
 	CommonEnable
 	CommonThingClass
 	CommonThingType
-	IsActive  *bool          `json:"is_active"`
-	IsGlobal  *bool          `json:"is_global"`
-	Schedules datatypes.JSON `json:"schedules"`
+	IsActive *bool          `json:"is_active"`
+	IsGlobal *bool          `json:"is_global"`
+	Schedule datatypes.JSON `json:"schedule"`
 	CommonCreated
+}
+
+type ScheduleData struct {
+	Schedules Schedules      `json:"schedules,omitempty"`
+	Config    datatypes.JSON `json:"config,omitempty"`
 }
 
 type Schedules struct {

--- a/model/writer.go
+++ b/model/writer.go
@@ -33,15 +33,10 @@ type SyncWriter struct {
 
 //WriterBody could be a local network, job or alarm and so on
 type WriterBody struct {
-	Action     string             `json:"action,omitempty"` //read, write and so on
-	AskRefresh bool               `json:"ask_refresh,omitempty"`
-	Priority   Priority           `json:"priority,omitempty"`
-	Schedule   ScheduleWriterBody `json:"schedule,omitempty"`
-}
-
-type ScheduleWriterBody struct {
-	Schedules Schedules      `json:"schedules,omitempty"`
-	Config    datatypes.JSON `json:"config,omitempty"`
+	Action     string       `json:"action,omitempty"` //read, write and so on
+	AskRefresh bool         `json:"ask_refresh,omitempty"`
+	Priority   Priority     `json:"priority,omitempty"`
+	Schedule   ScheduleData `json:"schedule,omitempty"`
 }
 
 //WriterBulk could be a local network, job or alarm and so on


### PR DESCRIPTION
### Summary

- Schedule has a `schedule` key instead of `schedules` and the schema will be like this (actually it should be another table, but we are storing it on JSON from earlier and we are keeping it as is for now):

```JSON
{
  ...
  ...
  ...
  "schedule": {
    "scheudles": {
      "events": {
        "59201e03": {
          "name": "HVAC",
          "dates": [
            {
              "start": "2021-12-16T03:00",
              "end": "2021-12-16T04:00"
            }
          ],
          "value": 20,
          "color": "#d0021b"
        }
      },
      "weekly": {
        "919d7b4c": {
          "name": "HVAC",
          "days": [
            "monday",
            "tuesday",
            "wednesday",
            "thursday",
            "friday"
          ],
          "start": "09:00",
          "end": "13:00",
          "value": 20,
          "color": "#4a90e2"
        }
      },
      "exceptions": {
        "34501ab2": {
          "name": "Christmas",
          "dates": [
            {
              "start": "2021-12-16T03:00",
              "end": "2021-12-16T04:00"
            }
          ],
          "value": 20,
          "color": "#d0021b"
        }
      },
      
    },
    "config": {
      "names": [
        "name1",
        "name2"
      ],
      "timezone": "Australia/Sydney"
    }
  }
}
```
- Update priority from priority array writer
- Schedule exception format change