### PR TITLE
Adds support for priority array modes

### DIFF
--- a/database/point.go
+++ b/database/point.go
@@ -31,7 +31,7 @@ func (d *GormDatabase) GetPoint(uuid string, args api.Args) (*model.Point, error
 
 func (d *GormDatabase) CreatePoint(body *model.Point, fromPlugin bool) (*model.Point, error) {
 	body.UUID = utils.MakeTopicUUID(model.ThingClass.Point)
-	deviceUUID := body.DeviceUUID
+	deviceUUID := body.DeviceUUID // Should there be a check to ensure that the DeviceUUID is sent with body?
 	body.Name = nameIsNil(body.Name)
 	existingAddrID := false
 	existingName, _ := d.pointNameExists(body)

--- a/database/point_funcs.go
+++ b/database/point_funcs.go
@@ -61,19 +61,27 @@ func (d *GormDatabase) GetOnePointByArgs(args api.Args) (*model.Point, error) {
 
 func (d *GormDatabase) updatePriority(pointModel *model.Point) (*model.Point, *float64) {
 	var presentValue *float64
+	presentValueFromPriority := pointModel.PointPriorityArrayMode != model.ReadOnlyNoPriorityArrayRequired && pointModel.PointPriorityArrayMode != model.PriorityArrayToWriteValue
 	if pointModel.Priority != nil {
 		priorityMap, highestValue, currentPriority, isPriorityExist := d.parsePriority(pointModel.Priority, pointModel)
 		if isPriorityExist {
 			pointModel.CurrentPriority = &currentPriority
-			presentValue = &highestValue
+			if presentValueFromPriority { // only update presentValue if required by PointPriorityArrayMode
+				presentValue = &highestValue
+			}
 		} else if !utils.FloatIsNilCheck(pointModel.Fallback) {
 			pointModel.Priority.P16 = utils.NewFloat64(*pointModel.Fallback)
 			pointModel.CurrentPriority = utils.NewInt(16)
-			presentValue = utils.NewFloat64(*pointModel.Fallback)
+			if presentValueFromPriority {
+				presentValue = utils.NewFloat64(*pointModel.Fallback) // only update presentValue if required by PointPriorityArrayMode
+			}
 		}
 		//writeValue := utils.Float64IsNil(pointModel.WriteValue)
 		d.DB.Model(&model.Point{}).Where("uuid = ?", pointModel.UUID).Update("write_value", pointModel.WriteValue)
 		d.DB.Model(&model.Priority{}).Where("point_uuid = ?", pointModel.UUID).Updates(&priorityMap)
+	}
+	if !presentValueFromPriority { // if presentValue doesn't come from priority array, update with the existing value
+		presentValue = pointModel.PresentValue
 	}
 	return pointModel, presentValue
 }

--- a/model/points.go
+++ b/model/points.go
@@ -1,0 +1,346 @@
+package model
+
+import "fmt"
+
+// TimeOverride TODO add in later
+//TimeOverride where a point value can be overridden for a duration of time
+type TimeOverride struct {
+	PointUUID string `json:"point_uuid" gorm:"REFERENCES points;not null;default:null;primaryKey"`
+	StartDate string `json:"start_date"` // START at 25:11:2021:13:00
+	EndDate   string `json:"end_date"`   // START at 25:11:2021:13:30
+	Value     string `json:"value"`
+	Priority  string `json:"priority"`
+}
+
+//MathOperation same as in lora and point-server TODO add in later
+type MathOperation struct {
+	Calc string //x + 1
+	X    float64
+}
+
+type ObjectType string
+
+const (
+	//bacnet
+	ObjTypeAnalogInput  ObjectType = "analog_input"
+	ObjTypeAnalogOutput ObjectType = "analog_output"
+	ObjTypeAnalogValue  ObjectType = "analog_value"
+	ObjTypeBinaryInput  ObjectType = "binary_input"
+	ObjTypeBinaryOutput ObjectType = "binary_output"
+	ObjTypeBinaryValue  ObjectType = "binary_value"
+	ObjAnalogInput      ObjectType = "analogInput"
+	ObjAnalogOutput     ObjectType = "analogOutput"
+	ObjAnalogValue      ObjectType = "analogValue"
+	ObjBinaryInput      ObjectType = "binaryInput"
+	ObjBinaryOutput     ObjectType = "binaryOutput"
+	ObjBinaryValue      ObjectType = "binaryValue"
+
+	//modbus
+	ObjTypeReadCoil           ObjectType = "read_coil"
+	ObjTypeReadCoils          ObjectType = "read_coils"
+	ObjTypeReadDiscreteInput  ObjectType = "read_discrete_input"
+	ObjTypeReadDiscreteInputs ObjectType = "read_discrete_inputs"
+	ObjTypeWriteCoil          ObjectType = "write_coil"
+	ObjTypeWriteCoils         ObjectType = "write_coils"
+	ObjTypeReadRegister       ObjectType = "read_register"
+	ObjTypeReadRegisters      ObjectType = "read_registers"
+	ObjTypeReadHolding        ObjectType = "read_holding"
+	ObjTypeReadHoldings       ObjectType = "read_holdings"
+	ObjTypeWriteHolding       ObjectType = "write_holding"
+	ObjTypeWriteHoldings      ObjectType = "write_holdings"
+	ObjTypeReadInt16          ObjectType = "read_int_16"
+	ObjTypeWriteInt16         ObjectType = "write_int_16"
+	ObjTypeReadUint16         ObjectType = "read_uint_16"
+	ObjTypeWriteUint16        ObjectType = "write_uint_16"
+	ObjTypeReadInt32          ObjectType = "read_int_32"
+	ObjTypeReadUint32         ObjectType = "read_uint_32"
+	ObjTypeReadFloat32        ObjectType = "read_float_32"
+	ObjTypeWriteFloat32       ObjectType = "write_float_32"
+	ObjTypeReadFloat64        ObjectType = "read_float_64"
+	ObjTypeWriteFloat64       ObjectType = "write_float_64"
+)
+
+var ObjectTypesMap = map[ObjectType]int8{
+	//bacnet
+	ObjTypeAnalogInput: 0, ObjTypeAnalogOutput: 0, ObjTypeAnalogValue: 0,
+	ObjTypeBinaryInput: 0, ObjTypeBinaryOutput: 0, ObjTypeBinaryValue: 0,
+	ObjAnalogInput: 0, ObjAnalogOutput: 0, ObjAnalogValue: 0,
+	ObjBinaryInput: 0, ObjBinaryOutput: 0, ObjBinaryValue: 0,
+	//modbus
+	ObjTypeReadCoil: 0, ObjTypeReadCoils: 0, ObjTypeReadDiscreteInput: 0,
+	ObjTypeReadDiscreteInputs: 0, ObjTypeWriteCoil: 0, ObjTypeWriteCoils: 0,
+	ObjTypeReadRegister: 0, ObjTypeReadRegisters: 0, ObjTypeReadHolding: 0,
+	ObjTypeReadHoldings: 0, ObjTypeWriteHolding: 0, ObjTypeWriteHoldings: 0,
+	ObjTypeReadInt16: 0, ObjTypeWriteInt16: 0,
+	ObjTypeReadUint16: 0, ObjTypeWriteUint16: 0,
+	ObjTypeReadInt32:   0,
+	ObjTypeReadUint32:  0,
+	ObjTypeReadFloat32: 0, ObjTypeWriteFloat32: 0,
+	ObjTypeReadFloat64: 0, ObjTypeWriteFloat64: 0,
+}
+
+type DataType string
+
+const (
+	TypeInt16   DataType = "int16"
+	TypeUint16  DataType = "uint16"
+	TypeInt32   DataType = "int32"
+	TypeUint32  DataType = "uint32"
+	TypeInt64   DataType = "int64"
+	TypeUint64  DataType = "uint64"
+	TypeFloat32 DataType = "float32"
+	TypeFloat64 DataType = "float64"
+)
+
+type ByteOrder string
+
+const (
+	ByteOrderLebBew ByteOrder = "leb_bew" //LITTLE_ENDIAN, HIGH_WORD_FIRST
+	ByteOrderLebLew ByteOrder = "leb_lew"
+	ByteOrderBebLew ByteOrder = "beb_lew"
+	ByteOrderBebBew ByteOrder = "beb_bew"
+)
+
+type IOType string
+
+const (
+	IOTypeRAW           IOType = "raw"
+	IOTypeDigital       IOType = "digital"
+	IOTypeAToDigital    IOType = "a_to_digital"
+	IOTypeVoltageDC     IOType = "voltage_dc"
+	IOTypeCurrent       IOType = "current"
+	IOTypeThermistor    IOType = "thermistor"
+	IOTypeThermistor10K IOType = "thermistor_10k_type_2"
+)
+
+//These are used to identify how the priority array is being used for the point.
+type PointPriorityArrayMode string
+
+const (
+	PriorityArrayToPresentValue     PointPriorityArrayMode = "priority_array_to_present_value"      //This is a normal point type
+	PriorityArrayToWriteValue       PointPriorityArrayMode = "priority_array_to_write_value"        //This is a point like a modbus writeable point which gets its present value from the read value, not directly from the priority array.
+	ReadOnlyNoPriorityArrayRequired PointPriorityArrayMode = "read_only_no_priority_array_required" //This is a point like a modbus read only point, which doesn't need a priority array, only a present value
+)
+
+//Point table
+type Point struct {
+	CommonUUID
+	CommonName
+	CommonDescription
+	CommonEnable
+	CommonCreated
+	CommonThingClass
+	CommonThingRef
+	CommonThingType
+	CommonFault
+	PresentValue         *float64  `json:"present_value"` //point value, read only
+	OriginalValue        *float64  `json:"original_value"`
+	WriteValue           *float64  `json:"write_value"`          //writeValue was added so if user wanted to do a math function on the point write
+	WriteValueOriginal   *float64  `json:"write_value_original"` //writeValue was added so if user wanted to do a math function on the point write
+	CurrentPriority      *int      `json:"current_priority,omitempty"`
+	InSync               *bool     `json:"in_sync"`                    //is set to false when a new value is written from the user example: if its false then modbus would write the new value. if user edits the point it will disable the COV for one time
+	WriteValueOnce       *bool     `json:"write_value_once,omitempty"` //when point is used for polling and if it's a writeable point and WriteValueOnce is true then on a successful write it will set the WriteValueOnceSync to true and on the next poll cycle it will not send the write value
+	WriteValueOnceSync   *bool     `json:"write_value_once_sync,omitempty"`
+	Fallback             *float64  `json:"fallback"`
+	DeviceUUID           string    `json:"device_uuid,omitempty" gorm:"TYPE:string REFERENCES devices;not null;default:null"`
+	EnableWriteable      *bool     `json:"writeable,omitempty"`
+	IsOutput             *bool     `json:"is_output,omitempty"`
+	MathOnPresentValue   string    `json:"math_on_present_value,omitempty"` // x+100
+	MathOnWriteValue     string    `json:"math_on_write_value,omitempty"`   // x*100
+	COV                  *float64  `json:"cov"`
+	ObjectType           string    `json:"object_type,omitempty"`     //binaryInput, coil, if type os input don't return the priority array
+	DataType             string    `json:"data_type,omitempty"`       //int16, uint16, float32
+	ObjectEncoding       string    `json:"object_encoding,omitempty"` //BEB_LEW bebLew
+	IoNumber             string    `json:"io_number,omitempty"`       //DI1,UI1,AO1, temp, pulse, motion
+	IoType               string    `json:"io_type,omitempty"`         //0-10dc, 0-40ma, thermistor
+	AddressID            *int      `json:"address_id"`                // for example a modbus address or bacnet address
+	AddressLength        *int      `json:"address_length"`            // for example a modbus address offset
+	AddressUUID          *string   `json:"address_uuid,omitempty"`    // for example a droplet id (so a string)
+	NextAvailableAddress *bool     `json:"use_next_available_address,omitempty"`
+	Decimal              *uint32   `json:"decimal,omitempty"`
+	LimitMin             *float64  `json:"limit_min"`
+	LimitMax             *float64  `json:"limit_max"`
+	ScaleInMin           *float64  `json:"scale_in_min"`
+	ScaleInMax           *float64  `json:"scale_in_max"`
+	ScaleOutMin          *float64  `json:"scale_out_min"`
+	ScaleOutMax          *float64  `json:"scale_out_max"`
+	UnitType             *string   `json:"unit_type,omitempty"` //temperature
+	Unit                 *string   `json:"unit,omitempty"`
+	UnitTo               *string   `json:"unit_to,omitempty"` //with take the unit and convert to, this would affect the presentValue and the original value will be stored in the raw
+	IsProducer           *bool     `json:"is_producer,omitempty"`
+	IsConsumer           *bool     `json:"is_consumer,omitempty"`
+	ValueRaw             string    `json:"value_raw,omitempty"`
+	Priority             *Priority `json:"priority,omitempty" gorm:"constraint:OnDelete:CASCADE"`
+	Tags                 []*Tag    `json:"tags,omitempty" gorm:"many2many:points_tags;constraint:OnDelete:CASCADE"`
+	ValueUpdatedFlag     *bool     `json:"value_updated_flag,omitempty"` //This is used when a plugin updates the PresentValue (not from priority array) and it triggers UpdatePointValue() to broadcast to producers. Should only be set to FALSE from UpdatePointValue().
+	//LastWrite
+	PointPriorityArrayMode PointPriorityArrayMode `json:"point_priority_use_type,omitempty"` //This configures how the point handles the priority array and present value.
+}
+
+type Priorities struct {
+	P1  *float64 `json:"_1"`
+	P2  *float64 `json:"_2"`
+	P3  *float64 `json:"_3"`
+	P4  *float64 `json:"_4"`
+	P5  *float64 `json:"_5"`
+	P6  *float64 `json:"_6"`
+	P7  *float64 `json:"_7"`
+	P8  *float64 `json:"_8"`
+	P9  *float64 `json:"_9"`
+	P10 *float64 `json:"_10"`
+	P11 *float64 `json:"_11"`
+	P12 *float64 `json:"_12"`
+	P13 *float64 `json:"_13"`
+	P14 *float64 `json:"_14"`
+	P15 *float64 `json:"_15"`
+	P16 *float64 `json:"_16"`
+}
+
+type Priority struct {
+	PointUUID string   `json:"point_uuid,omitempty" gorm:"REFERENCES points;not null;default:null;primaryKey"`
+	P1        *float64 `json:"_1"`
+	P2        *float64 `json:"_2"`
+	P3        *float64 `json:"_3"`
+	P4        *float64 `json:"_4"`
+	P5        *float64 `json:"_5"`
+	P6        *float64 `json:"_6"`
+	P7        *float64 `json:"_7"`
+	P8        *float64 `json:"_8"`
+	P9        *float64 `json:"_9"`
+	P10       *float64 `json:"_10"`
+	P11       *float64 `json:"_11"`
+	P12       *float64 `json:"_12"`
+	P13       *float64 `json:"_13"`
+	P14       *float64 `json:"_14"`
+	P15       *float64 `json:"_15"`
+	P16       *float64 `json:"_16"`
+}
+
+func (p *Priority) GetHighestPriorityValue() *float64 {
+	if p.P1 != nil {
+		return p.P1
+	}
+	if p.P2 != nil {
+		return p.P2
+	}
+	if p.P3 != nil {
+		return p.P3
+	}
+	if p.P4 != nil {
+		return p.P4
+	}
+	if p.P5 != nil {
+		return p.P5
+	}
+	if p.P6 != nil {
+		return p.P6
+	}
+	if p.P7 != nil {
+		return p.P7
+	}
+	if p.P8 != nil {
+		return p.P8
+	}
+	if p.P9 != nil {
+		return p.P9
+	}
+	if p.P10 != nil {
+		return p.P10
+	}
+	if p.P11 != nil {
+		return p.P11
+	}
+	if p.P12 != nil {
+		return p.P12
+	}
+	if p.P13 != nil {
+		return p.P13
+	}
+	if p.P14 != nil {
+		return p.P14
+	}
+	if p.P15 != nil {
+		return p.P15
+	}
+	if p.P16 != nil {
+		return p.P16
+	}
+	return nil
+}
+
+// For debugging.  TODO: This should be in utils, but creates a circular dependancy because `model` is imported in `utils/uuid.go`
+func (pnt *Point) PrintPointValues() {
+	if pnt != nil {
+		fmt.Println("\n ")
+		fmt.Println("PrintPointValues() for point: ", pnt.UUID, " ", pnt.Name)
+		if pnt.PresentValue == nil {
+			fmt.Println("PresentValue: nil")
+		} else {
+			fmt.Println("PresentValue: ", *pnt.PresentValue)
+		}
+		if pnt.CurrentPriority == nil {
+			fmt.Println("CurrentPriority: nil")
+		} else {
+			fmt.Println("CurrentPriority: ", *pnt.CurrentPriority)
+		}
+		if pnt.Priority != nil {
+			if pnt.Priority.P1 != nil {
+				fmt.Println("_1: ", *pnt.Priority.P1)
+			}
+			if pnt.Priority.P2 != nil {
+				fmt.Println("_2: ", *pnt.Priority.P2)
+			}
+			if pnt.Priority.P3 != nil {
+				fmt.Println("_3: ", *pnt.Priority.P3)
+			}
+			if pnt.Priority.P4 != nil {
+				fmt.Println("_4: ", *pnt.Priority.P4)
+			}
+			if pnt.Priority.P5 != nil {
+				fmt.Println("_5: ", *pnt.Priority.P5)
+			}
+			if pnt.Priority.P6 != nil {
+				fmt.Println("_6: ", *pnt.Priority.P6)
+			}
+			if pnt.Priority.P7 != nil {
+				fmt.Println("_7: ", *pnt.Priority.P7)
+			}
+			if pnt.Priority.P8 != nil {
+				fmt.Println("_8: ", *pnt.Priority.P8)
+			}
+			if pnt.Priority.P9 != nil {
+				fmt.Println("_9: ", *pnt.Priority.P9)
+			}
+			if pnt.Priority.P10 != nil {
+				fmt.Println("_10: ", *pnt.Priority.P10)
+			}
+			if pnt.Priority.P11 != nil {
+				fmt.Println("_11: ", *pnt.Priority.P11)
+			}
+			if pnt.Priority.P12 != nil {
+				fmt.Println("_12: ", *pnt.Priority.P12)
+			}
+			if pnt.Priority.P13 != nil {
+				fmt.Println("_13: ", *pnt.Priority.P13)
+			}
+			if pnt.Priority.P14 != nil {
+				fmt.Println("_14: ", *pnt.Priority.P14)
+			}
+			if pnt.Priority.P15 != nil {
+				fmt.Println("_15: ", *pnt.Priority.P15)
+			}
+			if pnt.Priority.P16 != nil {
+				fmt.Println("_16: ", *pnt.Priority.P16)
+			}
+		}
+		/* TODO: add in after polling branches have been merged.
+		if pnt.WritePollRequired != nil {
+			fmt.Println("WritePollRequired: ", *pnt.WritePollRequired)
+		}
+		if pnt.ReadPollRequired != nil {
+			fmt.Println("ReadPollRequired: ", *pnt.ReadPollRequired)
+		}
+		*/
+		fmt.Println("\n ")
+	}
+}

--- a/model/points_test.go
+++ b/model/points_test.go
@@ -1,17 +1,47 @@
 package model
 
 import (
+	"github.com/NubeIO/flow-framework/src/dbhandler"
 	"testing"
 )
 
 func TestPrintPointValues(*testing.T) {
 
-	var pnt Point
-	value := 16.0
-	var pri Priority
-	pri.P16 = &value
-	pnt.Priority = &pri
+	// Instance is plugin instance
+	type Instance struct {
+		db dbhandler.Handler
+	}
+	inst := &Instance{}
 
-	pnt.PrintPointValues()
+	//Create Point with priority array mode of PriorityArrayToWriteValue.
+	//This type uses the priority array to get a write value, then polls the protocol (eg modbus) to update the point presentValue.
+	var pnt Point
+	pnt.Name = "polledPointTest"
+	pnt.PointPriorityArrayMode = PriorityArrayToWriteValue
+
+	createdPoint, _ := inst.db.DB.CreatePoint(&pnt, true)
+
+	//Now update point write value.  Write value should be 10 @ priority 10.
+	//At this point the presentValue should still be null as there has not been a poll/write operation done.
+	value16 := 16.0
+	value10 := 10.0
+	var pri Priority
+	pri.P16 = &value16
+	pri.P10 = &value10
+	createdPoint.Priority = &pri
+
+	updatedPoint, _ := inst.db.DB.UpdatePoint(createdPoint.UUID, &pnt, false)
+
+	//THIS SECTION IS IN PLACE OF MODBUS (or other protocol) PLUGIN WHICH DOES A WRITE AND THEN READ TO GET THE PRESENT VALUE.
+	trueVar1 := true
+	updatedPoint.ValueUpdatedFlag = &trueVar1
+	floatVar1 := 10.0
+	updatedPoint.PresentValue = &floatVar1
+	trueVar2 := true
+	updatedPoint.InSync = &trueVar2
+
+	polledPoint, _ := inst.db.DB.UpdatePoint(updatedPoint.UUID, &pnt, true)
+
+	polledPoint.PrintPointValues()
 
 }

--- a/model/points_test.go
+++ b/model/points_test.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestPrintPointValues(*testing.T) {
+
+	var pnt Point
+	value := 16.0
+	var pri Priority
+	pri.P16 = &value
+	pnt.Priority = &pri
+
+	pnt.PrintPointValues()
+
+}

--- a/plugin/nube/protocals/modbus/enable.go
+++ b/plugin/nube/protocals/modbus/enable.go
@@ -21,6 +21,7 @@ func (inst *Instance) Enable() error {
 		if !inst.pollingEnabled {
 			var arg polling
 			inst.pollingEnabled = true
+			inst.PointWriteModeTest()
 			arg.enable = true
 			go func() error {
 				err := inst.PollingTCP(arg)

--- a/plugin/nube/protocals/modbus/write_mode_tst.go
+++ b/plugin/nube/protocals/modbus/write_mode_tst.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"github.com/NubeIO/flow-framework/model"
+	"github.com/NubeIO/flow-framework/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+func (inst *Instance) PointWriteModeTest() {
+
+	net := model.Network{}
+	net.Name = "TEST_NET_1"
+	net.TransportType = "ip"
+	net.PluginPath = "modbus"
+	createdNetwork, err := inst.db.CreateNetwork(&net, true)
+	log.Infof("network err: %+v\n", err)
+	log.Infof("network: %+v\n", createdNetwork)
+
+	dev := model.Device{}
+	dev.NetworkUUID = createdNetwork.UUID
+	dev.Name = "TEST_DEV_1"
+
+	createdDevice, err := inst.db.CreateDevice(&dev)
+
+	log.Infof("device err: %+v\n", err)
+	log.Infof("device: %+v\n", createdDevice)
+
+	//Create Point with priority array mode of PriorityArrayToWriteValue.
+	//This type uses the priority array to get a write value, then polls the protocol (eg modbus) to update the point presentValue.
+	var pnt model.Point
+	pnt.Name = "polledPointTest"
+	pnt.PointPriorityArrayMode = model.PriorityArrayToWriteValue
+	pnt.DeviceUUID = createdDevice.UUID
+
+	createdPoint, _ := inst.db.CreatePoint(&pnt, true, false)
+
+	log.Infof("createdPoint err: %+v\n", err)
+	log.Infof("createdPoint: %+v\n", createdPoint)
+
+	//Now update point write value.  Write value should be 10 @ priority 10.
+	//At this point the presentValue should still be null as there has not been a poll/write operation done.
+
+	var pri model.Priority
+	pri.P16 = utils.NewFloat64(16)
+	pri.P10 = utils.NewFloat64(10)
+	createdPoint.Priority = &pri
+
+	updatedPoint, _ := inst.db.UpdatePoint(createdPoint.UUID, &pnt, false)
+
+	log.Infof("updatedPoint err: %+v\n", err)
+	log.Infof("updatedPoint: %+v\n", updatedPoint)
+
+	updatedPoint.PrintPointValues()
+
+	//THIS SECTION IS IN PLACE OF MODBUS (or other protocol) PLUGIN WHICH DOES A WRITE AND THEN READ TO GET THE PRESENT VALUE.
+	updatedPoint.ValueUpdatedFlag = utils.NewTrue()
+	updatedPoint.PresentValue = utils.NewFloat64(10)
+	//updatedPoint.InSync = utils.NewTrue()
+
+	polledPoint, _ := inst.db.UpdatePoint(updatedPoint.UUID, updatedPoint, true)
+	//polledPoint, _ := inst.db.UpdatePointPresentValue(updatedPoint, true)
+
+	log.Infof("polledPoint err: %+v\n", err)
+	log.Infof("polledPoint: %+v\n", polledPoint)
+
+	polledPoint.PrintPointValues()
+
+}

--- a/src/dbhandler/points.go
+++ b/src/dbhandler/points.go
@@ -58,12 +58,6 @@ func (h *Handler) UpdatePointValue(uuid string, body *model.Point, fromPlugin bo
 		return nil, query.Error
 	}
 	_ = getDb().DB.Model(&pointModel).Updates(&body)
-	// Don't update point value if priority array on body is nil
-	if body.Priority == nil {
-		return pointModel, nil
-	} else {
-		pointModel.Priority = body.Priority
-	}
 	pointModel.Priority = body.Priority
 	p, err := getDb().UpdatePointValue(pointModel, fromPlugin)
 	if err != nil {


### PR DESCRIPTION
These changes add a new property `PointPriorityArrayMode` which configures the relationship between the `Priority` array and `presentValue`.   For polled points, like modbus, the `presentValue` is only updated from the polled `read` and not from the `Priority` array; in this case the `Priority` array values are used to establish the `write` value.  

There are a few changes to the way points are created/updated to support this functionality.  

Please review and merge if acceptable. These changes have been extracted from my `marc/polling-queue-move-to-plugin` branch.  I will raise the modbus/polling changes in another PR.  