### PR TITLE
Add PresentValue field in producer history

### DIFF
--- a/database/producer.go
+++ b/database/producer.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"encoding/json"
 	"errors"
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/flow-framework/src/client"
@@ -159,10 +158,9 @@ func (d *GormDatabase) producerPointWrite(uuid string, point *model.Point, produ
 		return err
 	}
 	if utils.BoolIsNil(producerModel.EnableHistory) && checkHistoryCovType(string(producerModel.HistoryType)) {
-		data, _ := json.Marshal(point.Priority)
 		ph := new(model.ProducerHistory)
 		ph.ProducerUUID = uuid
-		ph.DataStore = data
+		ph.PresentValue = point.PresentValue
 		ph.Timestamp = time.Now().UTC()
 		_, err = d.CreateProducerHistory(ph)
 		if err != nil {

--- a/database/producer_history.go
+++ b/database/producer_history.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"encoding/json"
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 )
@@ -63,15 +62,11 @@ func (d *GormDatabase) GetProducerHistoriesPoints(args api.Args) ([]*model.Histo
 		return nil, query.Error
 	}
 	for _, pHis := range proHistoriesModel {
-		priority := new(model.Priority)
-		_ = json.Unmarshal(pHis.DataStore, &priority)
-		highestPriorityValue := priority.GetHighestPriorityValue()
-		value := 0.0
-		if highestPriorityValue != nil {
-			value = *highestPriorityValue
+		if pHis.PresentValue == nil {
+			continue
 		}
 		historiesModel = append(historiesModel,
-			&model.History{ID: pHis.ID, UUID: pHis.ProducerUUID, Value: value, Timestamp: pHis.Timestamp})
+			&model.History{ID: pHis.ID, UUID: pHis.ProducerUUID, Value: *pHis.PresentValue, Timestamp: pHis.Timestamp})
 	}
 	return historiesModel, nil
 }
@@ -94,15 +89,11 @@ func (d *GormDatabase) GetProducerHistoriesPointsForSync(id string, timeStamp st
 		return nil, query.Error
 	}
 	for _, pHis := range proHistoriesModel {
-		priority := new(model.Priority)
-		_ = json.Unmarshal(pHis.DataStore, &priority)
-		highestPriorityValue := priority.GetHighestPriorityValue()
-		value := 0.0
-		if highestPriorityValue != nil {
-			value = *highestPriorityValue
+		if pHis.PresentValue == nil {
+			continue
 		}
 		historiesModel = append(historiesModel,
-			&model.History{ID: pHis.ID, UUID: pHis.ProducerUUID, Value: value, Timestamp: pHis.Timestamp})
+			&model.History{ID: pHis.ID, UUID: pHis.ProducerUUID, Value: *pHis.PresentValue, Timestamp: pHis.Timestamp})
 	}
 	return historiesModel, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/NubeDev/location v0.0.2
 	github.com/NubeIO/configor v0.0.3
 	github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.6
-	github.com/NubeIO/nubeio-rubix-lib-models-go v1.1.0
+	github.com/NubeIO/nubeio-rubix-lib-models-go v1.2.0
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/gin-contrib/cors v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,10 @@ github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.6/go.mod h1:iDKguImeSi6yhQlBK
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.0.4/go.mod h1:A1BPuc3UpE1EF3ugdf+8QIIKTT8s3eK+pfUcheJX2JM=
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.1.0 h1:++a2QLp/B6m85sKjksCfciLjO3oTOdc+wR1oBZt+KVg=
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.1.0/go.mod h1:J0Xy/dX/f/xIhEnW6ZhkE2LiyuRk2H9gCb0Uk+2SSSk=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.1.1 h1:Z/FmVAECRv+8rZIpHtJbCBBhqP/vXoY+0U9lrWKrf50=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.1.1/go.mod h1:J0Xy/dX/f/xIhEnW6ZhkE2LiyuRk2H9gCb0Uk+2SSSk=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.2.0 h1:cS+j8gh7kfK+EsXp6n5HBKVtAjSmsHGkgQ/DIf2u6dc=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.2.0/go.mod h1:J0Xy/dX/f/xIhEnW6ZhkE2LiyuRk2H9gCb0Uk+2SSSk=
 github.com/NubeIO/nubeio-rubix-lib-rest-go v1.0.4 h1:+mwlW6ZmSJbQOWBYxhuSv/E+WyRAwiVStw12ZqzXfIQ=
 github.com/NubeIO/nubeio-rubix-lib-rest-go v1.0.4/go.mod h1:rFKB8jY1/AzS862/4JtvEDzCMb/0J9BxjAQL+pF0MC8=
 github.com/PaesslerAG/gval v1.1.1 h1:4d7pprU9876+m3rc08X33UjGip8oV1kkm8Gh5GBuTss=

--- a/history/producer_history_sync_interval.go
+++ b/history/producer_history_sync_interval.go
@@ -1,7 +1,6 @@
 package history
 
 import (
-	"encoding/json"
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/go-co-op/gocron"
@@ -38,9 +37,9 @@ func (h *History) syncProducerHistoryInterval() {
 			latestPH.ProducerUUID = producer.UUID
 			latestPH.Timestamp = time.Date(currentDate.Year(), currentDate.Month(), currentDate.Day(),
 				currentDate.Hour(), minute, 0, 0, time.UTC)
-			point, _ := h.DB.GetPoint(producer.ProducerThingUUID, api.Args{WithPriority: true})
+			point, _ := h.DB.GetPoint(producer.ProducerThingUUID, api.Args{})
 			if point != nil {
-				latestPH.DataStore, _ = json.Marshal(point.Priority)
+				latestPH.PresentValue = point.PresentValue
 				_, err := h.DB.CreateProducerHistory(latestPH)
 				if err != nil {
 					log.Error(err)


### PR DESCRIPTION
Resolves: #471 
### Summary
- Addded `PresentValue` field in 'producer_histories' table.
- Added `PresentValue` and removed `DataStore` from producerPointWrite and syncProducerHistoryInterval.
- Modified `/histories/producers/points_for_sync` to get `PresentValue` for history sync