### PR TITLE
Release/0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## [v0.4.8](https://github.com/NubeIO/flow-framework/tree/v0.4.8) (2022-05-12)
+- Control COV streams on point value update
+
 ## [v0.4.7](https://github.com/NubeIO/flow-framework/tree/v0.4.7) (2022-05-12)
 - update to modbus-server plugin
 


### PR DESCRIPTION
### Summary

- Control COV streams on point value update
   - Due to this reason there the COV update was never used to get completed and used to show `http: Accept error: accept tcp [::]:1660: accept4: too many open files; retrying in 1s`