### PR TITLE
Example to fix `UpdatePoint()`

### DIFF
--- a/plugin/nube/protocals/modbus/debug.go
+++ b/plugin/nube/protocals/modbus/debug.go
@@ -8,7 +8,7 @@ import (
 )
 
 func modbusDebugMsg(args ...interface{}) {
-	debugMsgEnable := false
+	debugMsgEnable := true
 	if debugMsgEnable {
 		prefix := "Modbus: "
 		log.Info(prefix, args)

--- a/plugin/nube/protocals/modbus/polling.go
+++ b/plugin/nube/protocals/modbus/polling.go
@@ -94,7 +94,7 @@ func (inst *Instance) ModbusPolling() error {
 			//modbusDebugMsg(fmt.Sprintf("modbus-poll: POLL START: NAME: %s\n", net.Name))
 
 			if !boolean.IsTrue(net.Enable) {
-				modbusDebugMsg(fmt.Sprintf("NETWORK DISABLED: NAME: %s", net.Name))
+				//modbusDebugMsg(fmt.Sprintf("NETWORK DISABLED: NAME: %s", net.Name))
 				continue
 			}
 

--- a/plugin/nube/protocals/modbus/pollqueue/poll_queue.go
+++ b/plugin/nube/protocals/modbus/pollqueue/poll_queue.go
@@ -36,9 +36,11 @@ func (nq *NetworkPriorityPollQueue) AddPollingPoint(pp *PollingPoint) bool {
 		if pp.LockupAlertTimer != nil {
 			pp.LockupAlertTimer.Stop()
 		}
-		return false
-	}
-	if nq.StandbyPollingPoints.GetPollingPointIndexByPointUUID(pp.FFPointUUID) != -1 {
+		success := nq.PriorityQueue.RemovePollingPointByPointUUID(pp.FFPointUUID)
+		if !success {
+			return false
+		}
+	} else if nq.StandbyPollingPoints.GetPollingPointIndexByPointUUID(pp.FFPointUUID) != -1 {
 		//point exists in the StandbyPollingPoints list, remove it and add immediately.
 		nq.RemovePollingPointByPointUUID(pp.FFPointUUID)
 	}


### PR DESCRIPTION
DON'T MERGE, THIS IS JUST AN EXAMPLE!!

@RaiBnod the `database/point.go/UpdatePoint()` was broken with commit `bab51cb4a76119f2a3817afef2c4957e7a363b99`

`UpdatePointValue()` was removed from `UpdatePoint()` (and refactored).  This caused the Point `Present Value` not to be updated.  

In this branch I have added some code as an example of how this could be fixed.  I took the added `parsePriorityArrayFromPoint()` function (that makes a `*map[string]*float64` from the priority array) from the old `ParsePriority()` function.   This is just an example, and should be refactored into a seperate function call. 

Currently the only way to get a `model.PointWriter` is from an API call context (https://github.com/NubeIO/flow-framework/blob/29227e9d8390912ddb916287f749db5144d1e135/api/internal_utils.go#L457).  We need a function (like the one in my example code) that produces a `model.PointWriter` if the `UpdatePointValue()` function is to stay as it is written now. 
