### PR TITLE
Feature: sync flow networks

### DIFF
--- a/api/consumer.go
+++ b/api/consumer.go
@@ -14,7 +14,7 @@ type ConsumersDatabase interface {
 	UpdateConsumer(uuid string, body *model.Consumer) (*model.Consumer, error)
 	DeleteConsumer(uuid string) (bool, error)
 	DeleteConsumers(args Args) (bool, error)
-	SyncConsumerWriters(uuid string) []*interfaces.SyncModel
+	SyncConsumerWriters(uuid string) ([]*interfaces.SyncModel, error)
 }
 type ConsumersAPI struct {
 	DB ConsumersDatabase
@@ -64,6 +64,6 @@ func (j *ConsumersAPI) DeleteConsumers(ctx *gin.Context) {
 
 func (j *ConsumersAPI) SyncConsumerWriters(ctx *gin.Context) {
 	uuid := resolveID(ctx)
-	q := j.DB.SyncConsumerWriters(uuid)
-	responseHandler(q, nil, ctx)
+	q, err := j.DB.SyncConsumerWriters(uuid)
+	responseHandler(q, err, ctx)
 }

--- a/api/consumer.go
+++ b/api/consumer.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/asaskevich/govalidator"
 	"github.com/gin-gonic/gin"
@@ -13,6 +14,7 @@ type ConsumersDatabase interface {
 	UpdateConsumer(uuid string, body *model.Consumer) (*model.Consumer, error)
 	DeleteConsumer(uuid string) (bool, error)
 	DeleteConsumers(args Args) (bool, error)
+	SyncConsumerWriters(uuid string) []*interfaces.SyncModel
 }
 type ConsumersAPI struct {
 	DB ConsumersDatabase
@@ -58,4 +60,10 @@ func (j *ConsumersAPI) DeleteConsumers(ctx *gin.Context) {
 	args := buildConsumerArgs(ctx)
 	q, err := j.DB.DeleteConsumers(args)
 	responseHandler(q, err, ctx)
+}
+
+func (j *ConsumersAPI) SyncConsumerWriters(ctx *gin.Context) {
+	uuid := resolveID(ctx)
+	q := j.DB.SyncConsumerWriters(uuid)
+	responseHandler(q, nil, ctx)
 }

--- a/api/flow_network.go
+++ b/api/flow_network.go
@@ -15,8 +15,8 @@ type FlowNetworkDatabase interface {
 	UpdateFlowNetwork(uuid string, body *model.FlowNetwork) (*model.FlowNetwork, error)
 	DeleteFlowNetwork(uuid string) (bool, error)
 	RefreshFlowNetworksConnections() (*bool, error)
-	SyncFlowNetworks() []*interfaces.SyncModel
-	SyncFlowNetworkStreams(uuid string) ([]*interfaces.SyncModel, error)
+	SyncFlowNetworks(args Args) []*interfaces.SyncModel
+	SyncFlowNetworkStreams(uuid string, args Args) ([]*interfaces.SyncModel, error)
 }
 type FlowNetworksAPI struct {
 	DB FlowNetworkDatabase
@@ -66,12 +66,14 @@ func (a *FlowNetworksAPI) RefreshFlowNetworksConnections(ctx *gin.Context) {
 }
 
 func (a *FlowNetworksAPI) SyncFlowNetworks(ctx *gin.Context) {
-	q := a.DB.SyncFlowNetworks()
+	args := buildFlowNetworkArgs(ctx)
+	q := a.DB.SyncFlowNetworks(args)
 	responseHandler(q, nil, ctx)
 }
 
 func (a *FlowNetworksAPI) SyncFlowNetworkStreams(ctx *gin.Context) {
 	uuid := resolveID(ctx)
-	q, err := a.DB.SyncFlowNetworkStreams(uuid)
+	args := buildFlowNetworkArgs(ctx)
+	q, err := a.DB.SyncFlowNetworkStreams(uuid, args)
 	responseHandler(q, err, ctx)
 }

--- a/api/flow_network.go
+++ b/api/flow_network.go
@@ -16,6 +16,7 @@ type FlowNetworkDatabase interface {
 	DeleteFlowNetwork(uuid string) (bool, error)
 	RefreshFlowNetworksConnections() (*bool, error)
 	SyncFlowNetworks() []*interfaces.SyncModel
+	SyncFlowNetworkStreams(uuid string) []*interfaces.SyncModel
 }
 type FlowNetworksAPI struct {
 	DB FlowNetworkDatabase
@@ -66,5 +67,11 @@ func (a *FlowNetworksAPI) RefreshFlowNetworksConnections(ctx *gin.Context) {
 
 func (a *FlowNetworksAPI) SyncFlowNetworks(ctx *gin.Context) {
 	q := a.DB.SyncFlowNetworks()
+	responseHandler(q, nil, ctx)
+}
+
+func (a *FlowNetworksAPI) SyncFlowNetworkStreams(ctx *gin.Context) {
+	uuid := resolveID(ctx)
+	q := a.DB.SyncFlowNetworkStreams(uuid)
 	responseHandler(q, nil, ctx)
 }

--- a/api/flow_network.go
+++ b/api/flow_network.go
@@ -16,7 +16,7 @@ type FlowNetworkDatabase interface {
 	DeleteFlowNetwork(uuid string) (bool, error)
 	RefreshFlowNetworksConnections() (*bool, error)
 	SyncFlowNetworks() []*interfaces.SyncModel
-	SyncFlowNetworkStreams(uuid string) []*interfaces.SyncModel
+	SyncFlowNetworkStreams(uuid string) ([]*interfaces.SyncModel, error)
 }
 type FlowNetworksAPI struct {
 	DB FlowNetworkDatabase
@@ -72,6 +72,6 @@ func (a *FlowNetworksAPI) SyncFlowNetworks(ctx *gin.Context) {
 
 func (a *FlowNetworksAPI) SyncFlowNetworkStreams(ctx *gin.Context) {
 	uuid := resolveID(ctx)
-	q := a.DB.SyncFlowNetworkStreams(uuid)
-	responseHandler(q, nil, ctx)
+	q, err := a.DB.SyncFlowNetworkStreams(uuid)
+	responseHandler(q, err, ctx)
 }

--- a/api/flow_network.go
+++ b/api/flow_network.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/gin-gonic/gin"
 )
@@ -14,6 +15,7 @@ type FlowNetworkDatabase interface {
 	UpdateFlowNetwork(uuid string, body *model.FlowNetwork) (*model.FlowNetwork, error)
 	DeleteFlowNetwork(uuid string) (bool, error)
 	RefreshFlowNetworksConnections() (*bool, error)
+	SyncFlowNetworks() []*interfaces.SyncModel
 }
 type FlowNetworksAPI struct {
 	DB FlowNetworkDatabase
@@ -60,4 +62,9 @@ func (a *FlowNetworksAPI) DeleteFlowNetwork(ctx *gin.Context) {
 func (a *FlowNetworksAPI) RefreshFlowNetworksConnections(ctx *gin.Context) {
 	q, err := a.DB.RefreshFlowNetworksConnections()
 	responseHandler(q, err, ctx)
+}
+
+func (a *FlowNetworksAPI) SyncFlowNetworks(ctx *gin.Context) {
+	q := a.DB.SyncFlowNetworks()
+	responseHandler(q, nil, ctx)
 }

--- a/api/flow_network_clone.go
+++ b/api/flow_network_clone.go
@@ -13,8 +13,8 @@ type FlowNetworkCloneDatabase interface {
 	GetOneFlowNetworkCloneByArgs(args Args) (*model.FlowNetworkClone, error)
 	DeleteOneFlowNetworkCloneByArgs(args Args) (bool, error)
 	RefreshFlowNetworkClonesConnections() (*bool, error)
-	SyncFlowNetworkClones() ([]*interfaces.SyncModel, error)
-	SyncFlowNetworkCloneStreamClones(uuid string) ([]*interfaces.SyncModel, error)
+	SyncFlowNetworkClones(args Args) ([]*interfaces.SyncModel, error)
+	SyncFlowNetworkCloneStreamClones(uuid string, args Args) ([]*interfaces.SyncModel, error)
 }
 
 type FlowNetworkClonesAPI struct {
@@ -58,12 +58,14 @@ func (a *FlowNetworkClonesAPI) RefreshFlowNetworkClonesConnections(ctx *gin.Cont
 }
 
 func (a *FlowNetworkClonesAPI) SyncFlowNetworkClones(ctx *gin.Context) {
-	q, err := a.DB.SyncFlowNetworkClones()
+	args := buildFlowNetworkCloneArgs(ctx)
+	q, err := a.DB.SyncFlowNetworkClones(args)
 	responseHandler(q, err, ctx)
 }
 
 func (a *FlowNetworkClonesAPI) SyncFlowNetworkCloneStreamClones(ctx *gin.Context) {
 	uuid := resolveID(ctx)
-	q, err := a.DB.SyncFlowNetworkCloneStreamClones(uuid)
+	args := buildFlowNetworkCloneArgs(ctx)
+	q, err := a.DB.SyncFlowNetworkCloneStreamClones(uuid, args)
 	responseHandler(q, err, ctx)
 }

--- a/api/flow_network_clone.go
+++ b/api/flow_network_clone.go
@@ -13,6 +13,7 @@ type FlowNetworkCloneDatabase interface {
 	GetOneFlowNetworkCloneByArgs(args Args) (*model.FlowNetworkClone, error)
 	DeleteOneFlowNetworkCloneByArgs(args Args) (bool, error)
 	RefreshFlowNetworkClonesConnections() (*bool, error)
+	SyncFlowNetworkClones() ([]*interfaces.SyncModel, error)
 	SyncFlowNetworkCloneStreamClones(uuid string) ([]*interfaces.SyncModel, error)
 }
 
@@ -53,6 +54,11 @@ func (a *FlowNetworkClonesAPI) DeleteOneFlowNetworkCloneByArgs(ctx *gin.Context)
 
 func (a *FlowNetworkClonesAPI) RefreshFlowNetworkClonesConnections(ctx *gin.Context) {
 	q, err := a.DB.RefreshFlowNetworkClonesConnections()
+	responseHandler(q, err, ctx)
+}
+
+func (a *FlowNetworkClonesAPI) SyncFlowNetworkClones(ctx *gin.Context) {
+	q, err := a.DB.SyncFlowNetworkClones()
 	responseHandler(q, err, ctx)
 }
 

--- a/api/flow_network_clone.go
+++ b/api/flow_network_clone.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/gin-gonic/gin"
 )
@@ -12,6 +13,7 @@ type FlowNetworkCloneDatabase interface {
 	GetOneFlowNetworkCloneByArgs(args Args) (*model.FlowNetworkClone, error)
 	DeleteOneFlowNetworkCloneByArgs(args Args) (bool, error)
 	RefreshFlowNetworkClonesConnections() (*bool, error)
+	SyncFlowNetworkCloneStreamClones(uuid string) ([]*interfaces.SyncModel, error)
 }
 
 type FlowNetworkClonesAPI struct {
@@ -51,5 +53,11 @@ func (a *FlowNetworkClonesAPI) DeleteOneFlowNetworkCloneByArgs(ctx *gin.Context)
 
 func (a *FlowNetworkClonesAPI) RefreshFlowNetworkClonesConnections(ctx *gin.Context) {
 	q, err := a.DB.RefreshFlowNetworkClonesConnections()
+	responseHandler(q, err, ctx)
+}
+
+func (a *FlowNetworkClonesAPI) SyncFlowNetworkCloneStreamClones(ctx *gin.Context) {
+	uuid := resolveID(ctx)
+	q, err := a.DB.SyncFlowNetworkCloneStreamClones(uuid)
 	responseHandler(q, err, ctx)
 }

--- a/api/producer.go
+++ b/api/producer.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/asaskevich/govalidator"
 	"github.com/gin-gonic/gin"
@@ -35,6 +36,7 @@ type ProducerDatabase interface {
 	CreateProducer(body *model.Producer) (*model.Producer, error)
 	UpdateProducer(uuid string, body *model.Producer) (*model.Producer, error)
 	DeleteProducer(uuid string) (bool, error)
+	SyncProducerWriterClones(uuid string) ([]*interfaces.SyncModel, error)
 }
 type ProducerAPI struct {
 	DB ProducerDatabase
@@ -79,5 +81,11 @@ func (j *ProducerAPI) UpdateProducer(ctx *gin.Context) {
 func (j *ProducerAPI) DeleteProducer(ctx *gin.Context) {
 	uuid := resolveID(ctx)
 	q, err := j.DB.DeleteProducer(uuid)
+	responseHandler(q, err, ctx)
+}
+
+func (j *ProducerAPI) SyncProducerWriterClones(ctx *gin.Context) {
+	uuid := resolveID(ctx)
+	q, err := j.DB.SyncProducerWriterClones(uuid)
 	responseHandler(q, err, ctx)
 }

--- a/api/stream_clone.go
+++ b/api/stream_clone.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/gin-gonic/gin"
 )
@@ -10,6 +11,7 @@ type StreamCloneDatabase interface {
 	GetStreamClone(uuid string, args Args) (*model.StreamClone, error)
 	DeleteStreamClone(uuid string) (bool, error)
 	DeleteOneStreamCloneByArgs(args Args) (bool, error)
+	SyncStreamCloneConsumers(uuid string) []*interfaces.SyncModel
 }
 
 type StreamCloneAPI struct {
@@ -39,4 +41,10 @@ func (j *StreamCloneAPI) DeleteOneStreamCloneByArgs(ctx *gin.Context) {
 	args := buildStreamCloneArgs(ctx)
 	q, err := j.DB.DeleteOneStreamCloneByArgs(args)
 	responseHandler(q, err, ctx)
+}
+
+func (j *StreamCloneAPI) SyncStreamCloneConsumers(ctx *gin.Context) {
+	uuid := resolveID(ctx)
+	q := j.DB.SyncStreamCloneConsumers(uuid)
+	responseHandler(q, nil, ctx)
 }

--- a/api/stream_clone.go
+++ b/api/stream_clone.go
@@ -11,7 +11,7 @@ type StreamCloneDatabase interface {
 	GetStreamClone(uuid string, args Args) (*model.StreamClone, error)
 	DeleteStreamClone(uuid string) (bool, error)
 	DeleteOneStreamCloneByArgs(args Args) (bool, error)
-	SyncStreamCloneConsumers(uuid string) []*interfaces.SyncModel
+	SyncStreamCloneConsumers(uuid string) ([]*interfaces.SyncModel, error)
 }
 
 type StreamCloneAPI struct {
@@ -45,6 +45,6 @@ func (j *StreamCloneAPI) DeleteOneStreamCloneByArgs(ctx *gin.Context) {
 
 func (j *StreamCloneAPI) SyncStreamCloneConsumers(ctx *gin.Context) {
 	uuid := resolveID(ctx)
-	q := j.DB.SyncStreamCloneConsumers(uuid)
-	responseHandler(q, nil, ctx)
+	q, err := j.DB.SyncStreamCloneConsumers(uuid)
+	responseHandler(q, err, ctx)
 }

--- a/api/stream_clone.go
+++ b/api/stream_clone.go
@@ -11,7 +11,7 @@ type StreamCloneDatabase interface {
 	GetStreamClone(uuid string, args Args) (*model.StreamClone, error)
 	DeleteStreamClone(uuid string) (bool, error)
 	DeleteOneStreamCloneByArgs(args Args) (bool, error)
-	SyncStreamCloneConsumers(uuid string) ([]*interfaces.SyncModel, error)
+	SyncStreamCloneConsumers(uuid string, args Args) ([]*interfaces.SyncModel, error)
 }
 
 type StreamCloneAPI struct {
@@ -45,6 +45,7 @@ func (j *StreamCloneAPI) DeleteOneStreamCloneByArgs(ctx *gin.Context) {
 
 func (j *StreamCloneAPI) SyncStreamCloneConsumers(ctx *gin.Context) {
 	uuid := resolveID(ctx)
-	q, err := j.DB.SyncStreamCloneConsumers(uuid)
+	args := buildStreamCloneArgs(ctx)
+	q, err := j.DB.SyncStreamCloneConsumers(uuid, args)
 	responseHandler(q, err, ctx)
 }

--- a/api/streams.go
+++ b/api/streams.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/gin-gonic/gin"
 )
@@ -11,6 +12,7 @@ type StreamDatabase interface {
 	CreateStream(body *model.Stream) (*model.Stream, error)
 	UpdateStream(uuid string, body *model.Stream) (*model.Stream, error)
 	DeleteStream(uuid string) (bool, error)
+	SyncStreamProducers(uuid string, args Args) ([]*interfaces.SyncModel, error)
 }
 
 type StreamAPI struct {
@@ -46,5 +48,12 @@ func (j *StreamAPI) UpdateStream(ctx *gin.Context) {
 func (j *StreamAPI) DeleteStream(ctx *gin.Context) {
 	uuid := resolveID(ctx)
 	q, err := j.DB.DeleteStream(uuid)
+	responseHandler(q, err, ctx)
+}
+
+func (j *StreamAPI) SyncStreamProducers(ctx *gin.Context) {
+	uuid := resolveID(ctx)
+	args := buildStreamArgs(ctx)
+	q, err := j.DB.SyncStreamProducers(uuid, args)
 	responseHandler(q, err, ctx)
 }

--- a/database/consumer.go
+++ b/database/consumer.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"errors"
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/flow-framework/src/client"
@@ -95,9 +96,12 @@ func (d *GormDatabase) DeleteConsumers(args api.Args) (bool, error) {
 	return d.deleteResponseBuilder(query)
 }
 
-func (d *GormDatabase) SyncConsumerWriters(uuid string) []*interfaces.SyncModel {
+func (d *GormDatabase) SyncConsumerWriters(uuid string) ([]*interfaces.SyncModel, error) {
 	consumer, _ := d.GetConsumer(uuid, api.Args{WithWriters: true})
 	var outputs []*interfaces.SyncModel
+	if consumer == nil {
+		return nil, errors.New("not found consumer")
+	}
 	for _, writer := range consumer.Writers {
 		_, err := d.UpdateWriter(writer.UUID, writer)
 		var output interfaces.SyncModel
@@ -108,5 +112,5 @@ func (d *GormDatabase) SyncConsumerWriters(uuid string) []*interfaces.SyncModel 
 		}
 		outputs = append(outputs, &output)
 	}
-	return outputs
+	return outputs, nil
 }

--- a/database/consumer.go
+++ b/database/consumer.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/flow-framework/interfaces"
+	"github.com/NubeIO/flow-framework/interfaces/connection"
 	"github.com/NubeIO/flow-framework/src/client"
 	"github.com/NubeIO/flow-framework/urls"
 	"github.com/NubeIO/flow-framework/utils/nstring"
@@ -106,10 +107,15 @@ func (d *GormDatabase) SyncConsumerWriters(uuid string) ([]*interfaces.SyncModel
 		_, err := d.UpdateWriter(writer.UUID, writer)
 		var output interfaces.SyncModel
 		if err != nil {
+			writer.Connection = connection.Broken.String()
+			writer.Message = err.Error()
 			output = interfaces.SyncModel{UUID: writer.UUID, IsError: true, Message: nstring.New(err.Error())}
 		} else {
+			writer.Connection = connection.Connected.String()
+			writer.Message = ""
 			output = interfaces.SyncModel{UUID: writer.UUID, IsError: false}
 		}
+		_, _ = d.updateWriterWithoutSync(writer.UUID, writer)
 		outputs = append(outputs, &output)
 	}
 	return outputs, nil

--- a/database/consumer.go
+++ b/database/consumer.go
@@ -38,9 +38,9 @@ func (d *GormDatabase) CreateConsumer(body *model.Consumer) (*model.Consumer, er
 		return nil, newError("GetStreamClone", "error on trying to get validate the stream_clone_uuid")
 	}
 	flowNetworkCloneUUID := streamClone.FlowNetworkCloneUUID
-	fnc, err := d.GetOneFlowNetworkCloneByArgs(api.Args{UUID: &flowNetworkCloneUUID})
+	fnc, err := d.GetFlowNetworkClone(flowNetworkCloneUUID, api.Args{})
 	if err != nil {
-		return nil, newError("GetOneFlowNetworkCloneByArgs", "error on trying to get validate flow_network_clone from stream_clone_uuid")
+		return nil, newError("GetFlowNetworkClone", "error on trying to get validate flow_network_clone from stream_clone_uuid")
 	}
 	cli := client.NewFlowClientCliFromFNC(fnc)
 	rawProducer, err := cli.GetQueryMarshal(urls.SingularUrl(urls.ProducerUrl, body.ProducerUUID), model.Producer{})

--- a/database/consumer.go
+++ b/database/consumer.go
@@ -112,7 +112,7 @@ func (d *GormDatabase) SyncConsumerWriters(uuid string) ([]*interfaces.SyncModel
 			output = interfaces.SyncModel{UUID: writer.UUID, IsError: true, Message: nstring.New(err.Error())}
 		} else {
 			writer.Connection = connection.Connected.String()
-			writer.Message = ""
+			writer.Message = nstring.NotAvailable
 			output = interfaces.SyncModel{UUID: writer.UUID, IsError: false}
 		}
 		_, _ = d.updateWriterWithoutSync(writer.UUID, writer)

--- a/database/flow_network.go
+++ b/database/flow_network.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/flow-framework/config"
+	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/flow-framework/src/client"
 	"github.com/NubeIO/flow-framework/urls"
 	"github.com/NubeIO/flow-framework/utils/boolean"
@@ -147,6 +148,22 @@ func (d *GormDatabase) RefreshFlowNetworksConnections() (*bool, error) {
 		}
 	}
 	return boolean.NewTrue(), nil
+}
+
+func (d *GormDatabase) SyncFlowNetworks() []*interfaces.SyncModel {
+	fns, _ := d.GetFlowNetworks(api.Args{})
+	var outputs []*interfaces.SyncModel
+	for _, fn := range fns {
+		_, err := d.UpdateFlowNetwork(fn.UUID, fn)
+		var output interfaces.SyncModel
+		if err != nil {
+			output = interfaces.SyncModel{Id: fn.UUID, IsError: true, Message: nstring.New(err.Error())}
+		} else {
+			output = interfaces.SyncModel{Id: fn.UUID, IsError: false}
+		}
+		outputs = append(outputs, &output)
+	}
+	return outputs
 }
 
 func (d *GormDatabase) editFlowNetworkBody(body *model.FlowNetwork) (bool, *client.FlowClient, bool, *gorm.DB, error) {

--- a/database/flow_network.go
+++ b/database/flow_network.go
@@ -157,9 +157,25 @@ func (d *GormDatabase) SyncFlowNetworks() []*interfaces.SyncModel {
 		_, err := d.UpdateFlowNetwork(fn.UUID, fn)
 		var output interfaces.SyncModel
 		if err != nil {
-			output = interfaces.SyncModel{Id: fn.UUID, IsError: true, Message: nstring.New(err.Error())}
+			output = interfaces.SyncModel{UUID: fn.UUID, IsError: true, Message: nstring.New(err.Error())}
 		} else {
-			output = interfaces.SyncModel{Id: fn.UUID, IsError: false}
+			output = interfaces.SyncModel{UUID: fn.UUID, IsError: false}
+		}
+		outputs = append(outputs, &output)
+	}
+	return outputs
+}
+
+func (d *GormDatabase) SyncFlowNetworkStreams(uuid string) []*interfaces.SyncModel {
+	fn, _ := d.GetFlowNetwork(uuid, api.Args{WithStreams: true})
+	var outputs []*interfaces.SyncModel
+	for _, stream := range fn.Streams {
+		_, err := d.UpdateStream(stream.UUID, stream)
+		var output interfaces.SyncModel
+		if err != nil {
+			output = interfaces.SyncModel{UUID: stream.UUID, IsError: true, Message: nstring.New(err.Error())}
+		} else {
+			output = interfaces.SyncModel{UUID: stream.UUID, IsError: false}
 		}
 		outputs = append(outputs, &output)
 	}

--- a/database/flow_network.go
+++ b/database/flow_network.go
@@ -5,6 +5,7 @@ import (
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/flow-framework/config"
 	"github.com/NubeIO/flow-framework/interfaces"
+	"github.com/NubeIO/flow-framework/interfaces/connection"
 	"github.com/NubeIO/flow-framework/src/client"
 	"github.com/NubeIO/flow-framework/urls"
 	"github.com/NubeIO/flow-framework/utils/boolean"
@@ -157,10 +158,15 @@ func (d *GormDatabase) SyncFlowNetworks() []*interfaces.SyncModel {
 		_, err := d.UpdateFlowNetwork(fn.UUID, fn)
 		var output interfaces.SyncModel
 		if err != nil {
+			fn.Connection = connection.Broken.String()
+			fn.Message = err.Error()
 			output = interfaces.SyncModel{UUID: fn.UUID, IsError: true, Message: nstring.New(err.Error())}
 		} else {
+			fn.Connection = connection.Connected.String()
+			fn.Message = nstring.NotAvailable
 			output = interfaces.SyncModel{UUID: fn.UUID, IsError: false}
 		}
+		d.DB.Where("uuid = ?", fn.UUID).Updates(fn)
 		outputs = append(outputs, &output)
 	}
 	return outputs

--- a/database/flow_network.go
+++ b/database/flow_network.go
@@ -166,9 +166,12 @@ func (d *GormDatabase) SyncFlowNetworks() []*interfaces.SyncModel {
 	return outputs
 }
 
-func (d *GormDatabase) SyncFlowNetworkStreams(uuid string) []*interfaces.SyncModel {
+func (d *GormDatabase) SyncFlowNetworkStreams(uuid string) ([]*interfaces.SyncModel, error) {
 	fn, _ := d.GetFlowNetwork(uuid, api.Args{WithStreams: true})
 	var outputs []*interfaces.SyncModel
+	if fn == nil {
+		return nil, errors.New("no flow_network")
+	}
 	for _, stream := range fn.Streams {
 		_, err := d.UpdateStream(stream.UUID, stream)
 		var output interfaces.SyncModel
@@ -179,7 +182,7 @@ func (d *GormDatabase) SyncFlowNetworkStreams(uuid string) []*interfaces.SyncMod
 		}
 		outputs = append(outputs, &output)
 	}
-	return outputs
+	return outputs, nil
 }
 
 func (d *GormDatabase) editFlowNetworkBody(body *model.FlowNetwork) (bool, *client.FlowClient, bool, *gorm.DB, error) {

--- a/database/flow_network_clone.go
+++ b/database/flow_network_clone.go
@@ -104,7 +104,7 @@ func (d *GormDatabase) SyncFlowNetworkCloneStreamClones(uuid string) ([]*interfa
 				IsError: false,
 			}
 			sc.Connection = connection.Connected.String()
-			sc.Message = ""
+			sc.Message = nstring.NotAvailable
 		}
 		_ = d.updateStreamClone(sc.UUID, sc)
 		outputs = append(outputs, &output)

--- a/database/flow_network_clone.go
+++ b/database/flow_network_clone.go
@@ -88,7 +88,7 @@ func (d *GormDatabase) SyncFlowNetworkClones(args api.Args) ([]*interfaces.SyncM
 	for _, fnc := range fncs {
 		var output interfaces.SyncModel
 		cli := client.NewFlowClientCliFromFNC(fnc)
-		_, err := cli.GetQueryMarshal(urls.SingularUrl(urls.FlowNetworkUrl, fnc.SourceUUID), model.Writer{})
+		_, err := cli.GetQuery(urls.SingularUrl(urls.FlowNetworkUrl, fnc.SourceUUID))
 		if err != nil {
 			fnc.Message = err.Error()
 			fnc.Connection = connection.Broken.String()
@@ -123,7 +123,7 @@ func (d *GormDatabase) SyncFlowNetworkCloneStreamClones(uuid string, args api.Ar
 	for _, sc := range fnc.StreamClones {
 		var output interfaces.SyncModel
 		cli := client.NewFlowClientCliFromFNC(fnc)
-		_, err := cli.GetQueryMarshal(urls.SingularUrl(urls.StreamUrl, sc.SourceUUID), model.Writer{})
+		_, err := cli.GetQuery(urls.SingularUrl(urls.StreamUrl, sc.SourceUUID))
 		if err != nil {
 			output = interfaces.SyncModel{
 				UUID:    sc.UUID,

--- a/database/producer.go
+++ b/database/producer.go
@@ -134,13 +134,16 @@ func (d *GormDatabase) SyncProducerWriterClones(uuid string) ([]*interfaces.Sync
 		var output interfaces.SyncModel
 		fn, exists := flowNetworkMap[wc.FlowFrameworkUUID]
 		wc.Connection = connection.Connected.String()
+		wc.Message = ""
 		if !exists {
+			msg := "FlowNetwork is broken!"
 			output = interfaces.SyncModel{
 				UUID:    wc.UUID,
 				IsError: true,
-				Message: nstring.New("FlowNetwork is broken!"),
+				Message: nstring.New(msg),
 			}
 			wc.Connection = connection.Broken.String()
+			wc.Message = msg
 		} else {
 			cli := client.NewFlowClientCliFromFN(fn)
 			_, err := cli.GetQueryMarshal(urls.SingularUrl(urls.WriterUrl, wc.SourceUUID), model.Writer{})
@@ -151,6 +154,7 @@ func (d *GormDatabase) SyncProducerWriterClones(uuid string) ([]*interfaces.Sync
 					Message: nstring.New(err.Error()),
 				}
 				wc.Connection = connection.Broken.String()
+				wc.Message = err.Error()
 			}
 		}
 		_ = d.UpdateWriterClone(wc, wc)

--- a/database/producer.go
+++ b/database/producer.go
@@ -134,7 +134,7 @@ func (d *GormDatabase) SyncProducerWriterClones(uuid string) ([]*interfaces.Sync
 		var output interfaces.SyncModel
 		fn, exists := flowNetworkMap[wc.FlowFrameworkUUID]
 		wc.Connection = connection.Connected.String()
-		wc.Message = ""
+		wc.Message = nstring.NotAvailable
 		if !exists {
 			msg := "FlowNetwork is broken!"
 			output = interfaces.SyncModel{

--- a/database/producer.go
+++ b/database/producer.go
@@ -157,7 +157,7 @@ func (d *GormDatabase) SyncProducerWriterClones(uuid string) ([]*interfaces.Sync
 				wc.Message = err.Error()
 			}
 		}
-		_ = d.UpdateWriterClone(wc, wc)
+		_ = d.updateWriterClone(wc.UUID, wc)
 		outputs = append(outputs, &output)
 	}
 	return outputs, nil

--- a/database/producer.go
+++ b/database/producer.go
@@ -146,7 +146,7 @@ func (d *GormDatabase) SyncProducerWriterClones(uuid string) ([]*interfaces.Sync
 			wc.Message = msg
 		} else {
 			cli := client.NewFlowClientCliFromFN(fn)
-			_, err := cli.GetQueryMarshal(urls.SingularUrl(urls.WriterUrl, wc.SourceUUID), model.Writer{})
+			_, err := cli.GetQuery(urls.SingularUrl(urls.WriterUrl, wc.SourceUUID))
 			if err != nil {
 				output = interfaces.SyncModel{
 					UUID:    wc.UUID,

--- a/database/stream_clone.go
+++ b/database/stream_clone.go
@@ -57,6 +57,14 @@ func (d *GormDatabase) DeleteOneStreamCloneByArgs(args api.Args) (bool, error) {
 	return d.deleteResponseBuilder(query)
 }
 
+func (d *GormDatabase) updateStreamClone(uuid string, body *model.StreamClone) error {
+	query := d.DB.Where("uuid = ?", uuid).Updates(body)
+	if query.Error != nil {
+		return query.Error
+	}
+	return nil
+}
+
 func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) ([]*interfaces.SyncModel, error) {
 	streamClone, _ := d.GetStreamClone(uuid, api.Args{WithConsumers: true})
 	if streamClone == nil {

--- a/database/stream_clone.go
+++ b/database/stream_clone.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"errors"
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/flow-framework/interfaces/connection"
@@ -56,8 +57,11 @@ func (d *GormDatabase) DeleteOneStreamCloneByArgs(args api.Args) (bool, error) {
 	return d.deleteResponseBuilder(query)
 }
 
-func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) []*interfaces.SyncModel {
+func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) ([]*interfaces.SyncModel, error) {
 	streamClone, _ := d.GetStreamClone(uuid, api.Args{WithConsumers: true})
+	if streamClone == nil {
+		return nil, errors.New("no stream_clone")
+	}
 	flowNetworkClone, _ := d.GetFlowNetworkClone(streamClone.FlowNetworkCloneUUID, api.Args{})
 	cli := client.NewFlowClientCliFromFNC(flowNetworkClone)
 	var outputs []*interfaces.SyncModel
@@ -79,5 +83,5 @@ func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) []*interfaces.SyncM
 		_, _ = d.UpdateConsumer(consumer.UUID, consumer)
 		outputs = append(outputs, &output)
 	}
-	return outputs
+	return outputs, nil
 }

--- a/database/stream_clone.go
+++ b/database/stream_clone.go
@@ -71,10 +71,12 @@ func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) ([]*interfaces.Sync
 		if err != nil {
 			output = interfaces.SyncModel{UUID: consumer.UUID, IsError: true, Message: nstring.New(err.Error())}
 			consumer.Connection = connection.Broken.String()
+			consumer.Message = err.Error()
 		} else {
 			output = interfaces.SyncModel{UUID: consumer.UUID, IsError: false}
 			producer := rawProducer.(*model.Producer)
 			consumer.Connection = connection.Connected.String()
+			consumer.Message = ""
 			consumer.ProducerThingName = producer.ProducerThingName
 			consumer.ProducerThingUUID = producer.ProducerThingUUID
 			consumer.ProducerThingClass = producer.ProducerThingClass

--- a/database/stream_clone.go
+++ b/database/stream_clone.go
@@ -84,13 +84,13 @@ func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) ([]*interfaces.Sync
 			output = interfaces.SyncModel{UUID: consumer.UUID, IsError: false}
 			producer := rawProducer.(*model.Producer)
 			consumer.Connection = connection.Connected.String()
-			consumer.Message = ""
+			consumer.Message = nstring.NotAvailable
 			consumer.ProducerThingName = producer.ProducerThingName
 			consumer.ProducerThingUUID = producer.ProducerThingUUID
 			consumer.ProducerThingClass = producer.ProducerThingClass
 			consumer.ProducerThingType = producer.ProducerThingType
 		}
-		_, _ = d.UpdateConsumer(consumer.UUID, consumer)
+		d.DB.Where("uuid = ?", consumer.UUID).Updates(consumer)
 		outputs = append(outputs, &output)
 	}
 	return outputs, nil

--- a/database/stream_clone.go
+++ b/database/stream_clone.go
@@ -2,6 +2,11 @@ package database
 
 import (
 	"github.com/NubeIO/flow-framework/api"
+	"github.com/NubeIO/flow-framework/interfaces"
+	"github.com/NubeIO/flow-framework/interfaces/connection"
+	"github.com/NubeIO/flow-framework/src/client"
+	"github.com/NubeIO/flow-framework/urls"
+	"github.com/NubeIO/flow-framework/utils/nstring"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 )
 
@@ -49,4 +54,30 @@ func (d *GormDatabase) DeleteOneStreamCloneByArgs(args api.Args) (bool, error) {
 	}
 	query = query.Delete(&streamCloneModel)
 	return d.deleteResponseBuilder(query)
+}
+
+func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) []*interfaces.SyncModel {
+	streamClone, _ := d.GetStreamClone(uuid, api.Args{WithConsumers: true})
+	flowNetworkClone, _ := d.GetFlowNetworkClone(streamClone.FlowNetworkCloneUUID, api.Args{})
+	cli := client.NewFlowClientCliFromFNC(flowNetworkClone)
+	var outputs []*interfaces.SyncModel
+	for _, consumer := range streamClone.Consumers {
+		rawProducer, err := cli.GetQueryMarshal(urls.SingularUrl(urls.ProducerUrl, consumer.ProducerUUID), model.Producer{})
+		var output interfaces.SyncModel
+		if err != nil {
+			output = interfaces.SyncModel{UUID: consumer.UUID, IsError: true, Message: nstring.New(err.Error())}
+			consumer.Connection = connection.Broken.String()
+		} else {
+			output = interfaces.SyncModel{UUID: consumer.UUID, IsError: false}
+			producer := rawProducer.(*model.Producer)
+			consumer.Connection = connection.Connected.String()
+			consumer.ProducerThingName = producer.ProducerThingName
+			consumer.ProducerThingUUID = producer.ProducerThingUUID
+			consumer.ProducerThingClass = producer.ProducerThingClass
+			consumer.ProducerThingType = producer.ProducerThingType
+		}
+		_, _ = d.UpdateConsumer(consumer.UUID, consumer)
+		outputs = append(outputs, &output)
+	}
+	return outputs
 }

--- a/database/stream_clone.go
+++ b/database/stream_clone.go
@@ -65,7 +65,7 @@ func (d *GormDatabase) updateStreamClone(uuid string, body *model.StreamClone) e
 	return nil
 }
 
-func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) ([]*interfaces.SyncModel, error) {
+func (d *GormDatabase) SyncStreamCloneConsumers(uuid string, args api.Args) ([]*interfaces.SyncModel, error) {
 	streamClone, _ := d.GetStreamClone(uuid, api.Args{WithConsumers: true})
 	if streamClone == nil {
 		return nil, errors.New("no stream_clone")
@@ -73,6 +73,7 @@ func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) ([]*interfaces.Sync
 	flowNetworkClone, _ := d.GetFlowNetworkClone(streamClone.FlowNetworkCloneUUID, api.Args{})
 	cli := client.NewFlowClientCliFromFNC(flowNetworkClone)
 	var outputs []*interfaces.SyncModel
+	var localCli *client.FlowClient
 	for _, consumer := range streamClone.Consumers {
 		rawProducer, err := cli.GetQueryMarshal(urls.SingularUrl(urls.ProducerUrl, consumer.ProducerUUID), model.Producer{})
 		var output interfaces.SyncModel
@@ -89,6 +90,14 @@ func (d *GormDatabase) SyncStreamCloneConsumers(uuid string) ([]*interfaces.Sync
 			consumer.ProducerThingUUID = producer.ProducerThingUUID
 			consumer.ProducerThingClass = producer.ProducerThingClass
 			consumer.ProducerThingType = producer.ProducerThingType
+		}
+		// This is for syncing child descendants
+		if args.WithWriters {
+			if localCli == nil {
+				localCli = client.NewLocalClient()
+			}
+			url := urls.GetUrl(urls.ConsumerWritersSyncUrl, consumer.UUID)
+			_, _ = localCli.GetQuery(url)
 		}
 		d.DB.Where("uuid = ?", consumer.UUID).Updates(consumer)
 		outputs = append(outputs, &output)

--- a/database/sync_flow_network.go
+++ b/database/sync_flow_network.go
@@ -45,7 +45,7 @@ func (d *GormDatabase) SyncFlowNetwork(body *model.FlowNetwork) (*model.FlowNetw
 	d.DB.Where("global_uuid = ? ", body.GlobalUUID).Find(&flowNetworkClonesModel)
 	if len(flowNetworkClonesModel) == 0 {
 		fnc.UUID = nuuid.MakeTopicUUID(model.CommonNaming.FlowNetworkClone)
-		if err = d.DB.Create(fnc).Error; err != nil {
+		if err = d.DB.Create(&fnc).Error; err != nil {
 			return nil, err
 		}
 	} else {

--- a/database/sync_writer.go
+++ b/database/sync_writer.go
@@ -65,7 +65,7 @@ func (d *GormDatabase) SyncWriterWriteAction(sourceUUID string, body *model.Sync
 	if writerClone.WriterThingClass == model.ThingClass.Point {
 		data, _ := json.Marshal(body.Priority)
 		writerCloneBody := model.WriterClone{CommonWriter: model.CommonWriter{DataStore: data}}
-		err = d.UpdateWriterClone(writerClone, &writerCloneBody)
+		err = d.updateWriterClone(writerClone.UUID, &writerCloneBody)
 		if err != nil {
 			return nil
 		}
@@ -79,7 +79,7 @@ func (d *GormDatabase) SyncWriterWriteAction(sourceUUID string, body *model.Sync
 	} else if writerClone.WriterThingClass == model.ThingClass.Schedule {
 		data, _ := json.Marshal(body.Schedule)
 		writerCloneBody := model.WriterClone{CommonWriter: model.CommonWriter{DataStore: data}}
-		err = d.UpdateWriterClone(writerClone, &writerCloneBody)
+		err = d.updateWriterClone(writerClone.UUID, &writerCloneBody)
 		if err != nil {
 			return nil
 		}

--- a/database/writer_clone.go
+++ b/database/writer_clone.go
@@ -53,8 +53,8 @@ func (d *GormDatabase) DeleteWriterClone(uuid string) (bool, error) {
 	return d.deleteResponseBuilder(query)
 }
 
-func (d *GormDatabase) UpdateWriterClone(writerClone *model.WriterClone, body *model.WriterClone) error {
-	query := d.DB.Model(&writerClone).Updates(body)
+func (d *GormDatabase) updateWriterClone(uuid string, body *model.WriterClone) error {
+	query := d.DB.Where("uuid = ?", uuid).Updates(body)
 	if query.Error != nil {
 		return query.Error
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/NubeDev/location v0.0.2
 	github.com/NubeIO/configor v0.0.3
 	github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.6
-	github.com/NubeIO/nubeio-rubix-lib-models-go v1.2.3
+	github.com/NubeIO/nubeio-rubix-lib-models-go v1.2.4
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/gin-contrib/cors v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/NubeIO/configor v0.0.3/go.mod h1:HGAnJTAwAntKAi5EGMQUQHWE4o4fMYKyByWX
 github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.6 h1:DM3rn/11ZsbPH/87sm9d+7OAGKeUmR4DDr//YyXxxZo=
 github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.6/go.mod h1:iDKguImeSi6yhQlBKynEnOIKPOM6E9hPuxq2CnFHbpg=
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.0.4/go.mod h1:A1BPuc3UpE1EF3ugdf+8QIIKTT8s3eK+pfUcheJX2JM=
-github.com/NubeIO/nubeio-rubix-lib-models-go v1.2.3 h1:bcEpbLpn+xVaT/r9MiVwUWc2dbkKHC/TEJc9hXStKLQ=
-github.com/NubeIO/nubeio-rubix-lib-models-go v1.2.3/go.mod h1:J0Xy/dX/f/xIhEnW6ZhkE2LiyuRk2H9gCb0Uk+2SSSk=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.2.4 h1:44Tos3Zbfep20ZdtYQpoFebEYIbrLHdoc82QcsCU17o=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.2.4/go.mod h1:J0Xy/dX/f/xIhEnW6ZhkE2LiyuRk2H9gCb0Uk+2SSSk=
 github.com/NubeIO/nubeio-rubix-lib-rest-go v1.0.6 h1:vQRoKT3vVv+cbI2Sb1Djfgc7etZ93nxmFa83J35C4zA=
 github.com/NubeIO/nubeio-rubix-lib-rest-go v1.0.6/go.mod h1:lRsVVVKF9T3b2l5tL39jpeF6NaqLELYuM4qiof9MShc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/interfaces/connection/connection.go
+++ b/interfaces/connection/connection.go
@@ -1,0 +1,18 @@
+package connection
+
+type Connection int64
+
+const (
+	Connected Connection = iota
+	Broken
+)
+
+func (s Connection) String() string {
+	switch s {
+	case Connected:
+		return "Connected"
+	case Broken:
+		return "Broken"
+	}
+	return "Broken"
+}

--- a/interfaces/sync.go
+++ b/interfaces/sync.go
@@ -1,0 +1,7 @@
+package interfaces
+
+type SyncModel struct {
+	Id      string  `json:"id"`
+	IsError bool    `json:"is_error"`
+	Message *string `json:"message"`
+}

--- a/interfaces/sync.go
+++ b/interfaces/sync.go
@@ -1,7 +1,7 @@
 package interfaces
 
 type SyncModel struct {
-	Id      string  `json:"id"`
+	UUID    string  `json:"uuid"`
 	IsError bool    `json:"is_error"`
 	Message *string `json:"message"`
 }

--- a/plugin/nube/utils/backup/model/model.go
+++ b/plugin/nube/utils/backup/model/model.go
@@ -1,8 +1,0 @@
-package model
-
-// Message is a message wrapper with the channel, sender and recipient.
-type Message struct {
-	Msg         plugin.Message
-	ChannelName string
-	IsSend      bool
-}

--- a/router/router.go
+++ b/router/router.go
@@ -205,6 +205,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			flowNetworkRoutes.DELETE("/:uuid", flowNetwork.DeleteFlowNetwork)
 			flowNetworkRoutes.GET("/one/args", flowNetwork.GetOneFlowNetworkByArgs)
 			flowNetworkRoutes.GET("/refresh_connections", flowNetwork.RefreshFlowNetworksConnections)
+			flowNetworkRoutes.GET("/sync", flowNetwork.SyncFlowNetworks)
 		}
 
 		flowNetworkCloneRoutes := apiRoutes.Group("/flow_network_clones")

--- a/router/router.go
+++ b/router/router.go
@@ -217,6 +217,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			flowNetworkCloneRoutes.GET("/one/args", flowNetworkCloneHandler.GetOneFlowNetworkCloneByArgs)
 			flowNetworkCloneRoutes.DELETE("/one/args", flowNetworkCloneHandler.DeleteOneFlowNetworkCloneByArgs)
 			flowNetworkCloneRoutes.GET("/refresh_connections", flowNetworkCloneHandler.RefreshFlowNetworkClonesConnections)
+			flowNetworkCloneRoutes.GET("/sync", flowNetworkCloneHandler.SyncFlowNetworkClones)
 			flowNetworkCloneRoutes.GET("/:uuid/sync/stream_clones", flowNetworkCloneHandler.SyncFlowNetworkCloneStreamClones)
 		}
 

--- a/router/router.go
+++ b/router/router.go
@@ -239,6 +239,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			streamCloneRoutes.GET("/:uuid", streamCloneHandler.GetStreamClone)
 			streamCloneRoutes.DELETE("/:uuid", streamCloneHandler.DeleteStreamClone)
 			streamCloneRoutes.DELETE("/one/args", streamCloneHandler.DeleteOneStreamCloneByArgs)
+			streamCloneRoutes.GET("/:uuid/sync/consumers", streamCloneHandler.SyncStreamCloneConsumers)
 		}
 
 		networkRoutes := apiRoutes.Group("/networks")

--- a/router/router.go
+++ b/router/router.go
@@ -42,7 +42,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 	jobHandler := api.JobAPI{
 		DB: db,
 	}
-	gatewayHandler := api.StreamAPI{
+	streamHandler := api.StreamAPI{
 		DB: db,
 	}
 	streamCloneHandler := api.StreamCloneAPI{
@@ -223,11 +223,12 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 
 		streamRoutes := apiRoutes.Group("/streams")
 		{
-			streamRoutes.GET("/", gatewayHandler.GetStreams)
-			streamRoutes.POST("/", gatewayHandler.CreateStream)
-			streamRoutes.GET("/:uuid", gatewayHandler.GetStream)
-			streamRoutes.PATCH("/:uuid", gatewayHandler.UpdateStream)
-			streamRoutes.DELETE("/:uuid", gatewayHandler.DeleteStream)
+			streamRoutes.GET("/", streamHandler.GetStreams)
+			streamRoutes.POST("/", streamHandler.CreateStream)
+			streamRoutes.GET("/:uuid", streamHandler.GetStream)
+			streamRoutes.PATCH("/:uuid", streamHandler.UpdateStream)
+			streamRoutes.DELETE("/:uuid", streamHandler.DeleteStream)
+			streamRoutes.GET("/:uuid/sync/producers", streamHandler.SyncStreamProducers)
 		}
 
 		mappingRoutes := apiRoutes.Group("/mapping")

--- a/router/router.go
+++ b/router/router.go
@@ -206,6 +206,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			flowNetworkRoutes.GET("/one/args", flowNetwork.GetOneFlowNetworkByArgs)
 			flowNetworkRoutes.GET("/refresh_connections", flowNetwork.RefreshFlowNetworksConnections)
 			flowNetworkRoutes.GET("/sync", flowNetwork.SyncFlowNetworks)
+			flowNetworkRoutes.GET("/sync/streams/:uuid", flowNetwork.SyncFlowNetworkStreams)
 		}
 
 		flowNetworkCloneRoutes := apiRoutes.Group("/flow_network_clones")

--- a/router/router.go
+++ b/router/router.go
@@ -206,7 +206,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			flowNetworkRoutes.GET("/one/args", flowNetwork.GetOneFlowNetworkByArgs)
 			flowNetworkRoutes.GET("/refresh_connections", flowNetwork.RefreshFlowNetworksConnections)
 			flowNetworkRoutes.GET("/sync", flowNetwork.SyncFlowNetworks)
-			flowNetworkRoutes.GET("/sync/streams/:uuid", flowNetwork.SyncFlowNetworkStreams)
+			flowNetworkRoutes.GET("/:uuid/sync/streams", flowNetwork.SyncFlowNetworkStreams)
 		}
 
 		flowNetworkCloneRoutes := apiRoutes.Group("/flow_network_clones")
@@ -314,6 +314,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			consumerRoutes.PATCH("/:uuid", consumerHandler.UpdateConsumer)
 			consumerRoutes.DELETE("/:uuid", consumerHandler.DeleteConsumer)
 			consumerRoutes.DELETE("", consumerHandler.DeleteConsumers)
+			consumerRoutes.GET("/:uuid/sync/writers", consumerHandler.SyncConsumerWriters)
 
 			consumerWriterRoutes := consumerRoutes.Group("/writers")
 			{

--- a/router/router.go
+++ b/router/router.go
@@ -217,6 +217,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			flowNetworkCloneRoutes.GET("/one/args", flowNetworkCloneHandler.GetOneFlowNetworkCloneByArgs)
 			flowNetworkCloneRoutes.DELETE("/one/args", flowNetworkCloneHandler.DeleteOneFlowNetworkCloneByArgs)
 			flowNetworkCloneRoutes.GET("/refresh_connections", flowNetworkCloneHandler.RefreshFlowNetworkClonesConnections)
+			flowNetworkCloneRoutes.GET("/:uuid/sync/stream_clones", flowNetworkCloneHandler.SyncFlowNetworkCloneStreamClones)
 		}
 
 		streamRoutes := apiRoutes.Group("/streams")

--- a/router/router.go
+++ b/router/router.go
@@ -296,6 +296,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			producerRoutes.PATCH("/:uuid", producerHandler.UpdateProducer)
 			producerRoutes.DELETE("/:uuid", producerHandler.DeleteProducer)
 			producerRoutes.GET("/one/args", producerHandler.GetOneProducerByArgs)
+			producerRoutes.GET("/:uuid/sync/writer_clones", producerHandler.SyncProducerWriterClones)
 
 			producerWriterCloneRoutes := producerRoutes.Group("/writer_clones")
 			{

--- a/src/client/error.go
+++ b/src/client/error.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/rest/v1/rest"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -9,6 +10,19 @@ import (
 type Error struct {
 	Code    int    `json:"error_code,omitempty"`
 	Message string `json:"error_message,omitempty"`
+}
+
+func failedResponse(err error, resp *resty.Response) error {
+	if err != nil {
+		return err
+	}
+	if resp.Error() != nil {
+		return getAPIError(resp)
+	}
+	if rest.StatusCodesAllBad(resp.StatusCode()) {
+		return getAPIError(resp)
+	}
+	return nil
 }
 
 // Convert error response into error message

--- a/src/client/plugin.go
+++ b/src/client/plugin.go
@@ -2,9 +2,7 @@ package client
 
 import (
 	"fmt"
-	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/rest/v1/rest"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
-	"github.com/go-resty/resty/v2"
 )
 
 // ClientGetPlugins an object
@@ -30,20 +28,6 @@ func (a *FlowClient) ClientGetPlugin(uuid string) (*ResponseBody, error) {
 		return nil, failResponse
 	}
 	return resp.Result().(*ResponseBody), nil
-}
-
-func failedResponse(err error, resp *resty.Response) error {
-	if err != nil {
-		return fmt.Errorf("%s failed", err)
-	}
-	if resp.Error() != nil {
-		return getAPIError(resp)
-	}
-	if rest.StatusCodesAllBad(resp.StatusCode()) {
-		return getAPIError(resp)
-	}
-	return nil
-
 }
 
 // CreateNetworkPlugin an object

--- a/src/client/sync_flow_network.go
+++ b/src/client/sync_flow_network.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 )
 
@@ -10,15 +9,9 @@ func (a *FlowClient) SyncFlowNetwork(body *model.FlowNetwork) (*model.FlowNetwor
 		SetResult(&model.FlowNetworkClone{}).
 		SetBody(body).
 		Post("/api/sync/flow_network")
-	if err != nil {
-		if resp == nil || resp.String() == "" {
-			return nil, fmt.Errorf("SyncFlowNetwork: %s", err)
-		} else {
-			return nil, fmt.Errorf("SyncFlowNetwork: %s", resp)
-		}
-	}
-	if resp.IsError() {
-		return nil, fmt.Errorf("SyncFlowNetwork: %s", resp)
+	fr := failedResponse(err, resp)
+	if fr != nil {
+		return nil, err
 	}
 	return resp.Result().(*model.FlowNetworkClone), nil
 }

--- a/src/client/sync_writer.go
+++ b/src/client/sync_writer.go
@@ -10,12 +10,9 @@ func (a *FlowClient) SyncWriter(body *model.SyncWriter) (*model.WriterClone, err
 		SetResult(&model.WriterClone{}).
 		SetBody(body).
 		Post("/api/sync/writer")
-	if err != nil {
-		if resp == nil || resp.String() == "" {
-			return nil, fmt.Errorf("SyncWriter: %s", err)
-		} else {
-			return nil, fmt.Errorf("SyncWriter: %s", resp)
-		}
+	fr := failedResponse(err, resp)
+	if fr != nil {
+		return nil, fr
 	}
 	return resp.Result().(*model.WriterClone), nil
 }

--- a/src/client/system.go
+++ b/src/client/system.go
@@ -1,9 +1,5 @@
 package client
 
-import (
-	"fmt"
-)
-
 type Ping struct {
 	Health   string `json:"health"`
 	Database string `json:"database"`
@@ -13,15 +9,9 @@ func (a *FlowClient) Ping() (*Ping, error) {
 	resp, err := a.client.R().
 		SetResult(&Ping{}).
 		Get("/api/system/ping")
-	if err != nil {
-		if resp == nil || resp.String() == "" {
-			return nil, fmt.Errorf("ping: %s", err)
-		} else {
-			return nil, fmt.Errorf("ping: %s", resp)
-		}
-	}
-	if resp.IsError() {
-		return nil, fmt.Errorf("ping: %s", resp)
+	fr := failedResponse(err, resp)
+	if fr != nil {
+		return nil, err
 	}
 	return resp.Result().(*Ping), nil
 }

--- a/urls/urls.go
+++ b/urls/urls.go
@@ -5,9 +5,10 @@ import "fmt"
 const FlowNetworkUrl string = "/api/flow_network"
 const FlowNetworkCloneUrl string = "/api/flow_network_clones"
 const StreamCloneUrl string = "/api/stream_clones"
-const WriterCloneUrl string = "/api/producers/writer_clones"
 const ProducerUrl string = "/api/producers"
 const ConsumerUrl string = "/api/consumers"
+const WriterCloneUrl string = "/api/producers/writer_clones"
+const WriterUrl string = "/api/consumers/writers"
 
 func SingularUrl(url, uuid string) string {
 	return fmt.Sprintf("%s/%s", url, uuid)

--- a/urls/urls.go
+++ b/urls/urls.go
@@ -19,6 +19,10 @@ const FlowNetworkStreamsSyncUrl string = "/api/flow_networks/:uuid/sync/streams"
 const StreamProducersSyncUrl string = "/api/streams/:uuid/sync/producers"
 const ProducerWriterClonesSyncUrl string = "/api/producers/:uuid/sync/writer_clones"
 
+const FlowNetworkCloneStreamClonesSyncUrl string = "/api/flow_network_clones/:uuid/sync/stream_clones"
+const StreamCloneConsumersSyncUrl string = "/api/stream_clones/:uuid/sync/consumers"
+const ConsumerWritersSyncUrl string = "/api/consumers/:uuid/sync/writers"
+
 func SingularUrl(url, uuid string) string {
 	return fmt.Sprintf("%s/%s", url, uuid)
 }
@@ -40,5 +44,13 @@ func GenerateFNUrlParams(args api.Args) string {
 	var aType = api.ArgsType
 	params += fmt.Sprintf("%s=%v", aType.WithProducers, args.WithProducers)
 	params += fmt.Sprintf("&%s=%v", aType.WithWriterClones, args.WithWriterClones)
+	return params
+}
+
+func GenerateFNCUrlParams(args api.Args) string {
+	params := "?"
+	var aType = api.ArgsType
+	params += fmt.Sprintf("%s=%v", aType.WithConsumers, args.WithConsumers)
+	params += fmt.Sprintf("&%s=%v", aType.WithWriters, args.WithWriters)
 	return params
 }

--- a/urls/urls.go
+++ b/urls/urls.go
@@ -1,8 +1,12 @@
 package urls
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/NubeIO/flow-framework/api"
+	"strings"
+)
 
-const FlowNetworkUrl string = "/api/flow_network"
+const FlowNetworkUrl string = "/api/flow_networks"
 const FlowNetworkCloneUrl string = "/api/flow_network_clones"
 const StreamUrl string = "/api/streams"
 const StreamCloneUrl string = "/api/stream_clones"
@@ -10,6 +14,10 @@ const ProducerUrl string = "/api/producers"
 const ConsumerUrl string = "/api/consumers"
 const WriterCloneUrl string = "/api/producers/writer_clones"
 const WriterUrl string = "/api/consumers/writers"
+
+const FlowNetworkStreamsSyncUrl string = "/api/flow_networks/:uuid/sync/streams"
+const StreamProducersSyncUrl string = "/api/streams/:uuid/sync/producers"
+const ProducerWriterClonesSyncUrl string = "/api/producers/:uuid/sync/writer_clones"
 
 func SingularUrl(url, uuid string) string {
 	return fmt.Sprintf("%s/%s", url, uuid)
@@ -21,4 +29,16 @@ func SingularUrlByArg(url, name, value string) string {
 
 func PluralUrlByArg(url, name, value string) string {
 	return fmt.Sprintf("%s?%s=%s", url, name, value)
+}
+
+func GetUrl(url, uuid string) string {
+	return strings.Replace(url, ":uuid", uuid, -1)
+}
+
+func GenerateFNUrlParams(args api.Args) string {
+	params := "?"
+	var aType = api.ArgsType
+	params += fmt.Sprintf("%s=%v", aType.WithProducers, args.WithProducers)
+	params += fmt.Sprintf("&%s=%v", aType.WithWriterClones, args.WithWriterClones)
+	return params
 }

--- a/urls/urls.go
+++ b/urls/urls.go
@@ -4,6 +4,7 @@ import "fmt"
 
 const FlowNetworkUrl string = "/api/flow_network"
 const FlowNetworkCloneUrl string = "/api/flow_network_clones"
+const StreamUrl string = "/api/streams"
 const StreamCloneUrl string = "/api/stream_clones"
 const ProducerUrl string = "/api/producers"
 const ConsumerUrl string = "/api/consumers"

--- a/utils/nstring/string.go
+++ b/utils/nstring/string.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	NotAvailable         = "N/A"
 	First                = "first"
 	Last                 = "last"
 	OddError             = "odd number rule provided please provide in even count"


### PR DESCRIPTION
## Summary

### FlowNetwork Side
#### Sync> flow_network
  - Create flow_network_clone if it isn't created
  - Update flow_network_clone if it isn't updated
  - Update `connection` status to `Broken` or `Connected`
  - Update `message` if it's broken for some reason
  - API: `/api/flow_networks/sync`
  - API for syncing descendants too: `/api/flow_networks/sync?with_streams=true&with_producers=true&with_writer_clones=true`

#### Sync> flow_network's streams
  - It doesn't have fields connection & message on the model because it has the many-to-many relationship
  - It doesn't update anything (only helpful on passing sync requests for descendants)
  - API: `/api/flow_networks/<fn_uuid>/sync/streams`
  - API for syncing descendants too: `/api/flow_networks/<fn_uuid>/sync/streams?with_producers=true&with_writer_clones=true`

#### Sync> stream's producers
  - It doesn't have fields connection & message because it doesn't have the broken phase in any case
  - It doesn't update anything (only helpful on passing sync requests for descendants)
  - API: `/api/streams/<stream_uuid>/sync/producers`
  - API for syncing descendants too: `/api/streams/<stream_uuid>/sync/producers?with_writer_clones=true`

#### Sync> producer's writer_clones
  - Update `connection` status to `Broken` or `Connected`
  - Update `message` if it's broken for some reason
  - API: `/api/producers/<producer_uuid>/sync/writer_clones`

<br/>
<br/>

### FlowNetworkClone Side
#### Sync> flow_network_clone
  - Update `connection` status to `Broken` or `Connected`
  - Update `message` if it's broken for some reason
  - API: `/api/flow_network_clones/sync`
  - API for syncing descendants too: `/api/flow_network_clones/sync?with_stream_clones=true&with_consumers=true&with_writers=true`

#### Sync> flow_network_clone's stream_clones
  - Update `connection` status to `Broken` or `Connected`
  - Update `message` if it's broken for some reason
  - API: `/api/flow_network_clones/<fnc_uuid>/sync/stream_clones`
  - API for syncing descendants too: `/api/flow_network_clones/<fnc_uuid>/sync/stream_clones?with_consumers=true&with_writers=true`

#### Sync> stream_clone's consumers
  - Update `connection` status to `Broken` or `Connected`
  - Update `message` if it's broken for some reason
  - API: `/api/stream_clones/<stream_clone_uuid>/sync/consumers`
  - API for syncing descendants too: `/api/stream_clones/<stream_clone_uuid>/sync/consumers?with_writers=true`
  
#### Sync> consumer's writers
  - Update `connection` status to `Broken` or `Connected`
  - Update `message` if it's broken for some reason
  - API: `/api/consumers/<consumer_uuid>/sync/writers`
