### PR TITLE
Feature/metadata api

### DIFF
--- a/api/args.go
+++ b/api/args.go
@@ -60,6 +60,7 @@ type Args struct {
 	IoNumber             *string
 	IdGt                 *string
 	IsRemote             *bool
+	IsMetadata           bool
 }
 
 var ArgsType = struct {
@@ -122,6 +123,7 @@ var ArgsType = struct {
 	IoNumber             string
 	IdGt                 string
 	IsRemote             string
+	IsMetadata           string
 }{
 	Sort:                 "sort",
 	Order:                "order",
@@ -182,6 +184,7 @@ var ArgsType = struct {
 	IoNumber:             "io_number",
 	IdGt:                 "id_gt",
 	IsRemote:             "is_remote",
+	IsMetadata:           "is_metadata",
 }
 
 var ArgsDefault = struct {
@@ -223,6 +226,7 @@ var ArgsDefault = struct {
 	NetworkName       string
 	DeviceName        string
 	PointName         string
+	IsMetadata        string
 }{
 	Sort:              "ID",
 	Order:             "DESC", // ASC or DESC
@@ -261,4 +265,5 @@ var ArgsDefault = struct {
 	NetworkName:       "",
 	DeviceName:        "",
 	PointName:         "",
+	IsMetadata:        "false",
 }

--- a/api/args_builder.go
+++ b/api/args_builder.go
@@ -13,6 +13,7 @@ func buildFlowNetworkArgs(ctx *gin.Context) Args {
 	args.WithProducers, _ = toBool(ctx.DefaultQuery(aType.WithProducers, aDefault.WithProducers))
 	args.WithCommandGroups, _ = toBool(ctx.DefaultQuery(aType.WithCommandGroups, aDefault.WithCommandGroups))
 	args.WithWriterClones, _ = toBool(ctx.DefaultQuery(aType.WithWriterClones, aDefault.WithWriterClones))
+	args.IsMetadata, _ = toBool(ctx.DefaultQuery(aType.IsMetadata, aDefault.IsMetadata))
 	if val, exists := ctx.Get(aType.IsRemote); exists {
 		args.IsRemote = boolean.New(val.(bool))
 	}

--- a/api/args_builder.go
+++ b/api/args_builder.go
@@ -42,6 +42,7 @@ func buildFlowNetworkCloneArgs(ctx *gin.Context) Args {
 	args.WithStreamClones, _ = toBool(ctx.DefaultQuery(aType.WithStreamClones, aDefault.WithStreamClones))
 	args.WithConsumers, _ = toBool(ctx.DefaultQuery(aType.WithConsumers, aDefault.WithConsumers))
 	args.WithWriters, _ = toBool(ctx.DefaultQuery(aType.WithWriters, aDefault.WithWriters))
+	args.IsMetadata, _ = toBool(ctx.DefaultQuery(aType.IsMetadata, aDefault.IsMetadata))
 	if value, ok := ctx.GetQuery(aType.GlobalUUID); ok {
 		args.GlobalUUID = &value
 	}

--- a/api/flow_network.go
+++ b/api/flow_network.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/gin-gonic/gin"
@@ -25,6 +26,13 @@ type FlowNetworksAPI struct {
 func (a *FlowNetworksAPI) GetFlowNetworks(ctx *gin.Context) {
 	args := buildFlowNetworkArgs(ctx)
 	q, err := a.DB.GetFlowNetworks(args)
+	if err == nil && args.IsMetadata {
+		var flowNetworksMetaData []*interfaces.FlowNetworkMetadata
+		out, _ := json.Marshal(q)
+		_ = json.Unmarshal(out, &flowNetworksMetaData)
+		ResponseHandler(flowNetworksMetaData, err, ctx)
+		return
+	}
 	ResponseHandler(q, err, ctx)
 }
 

--- a/api/flow_network_clone.go
+++ b/api/flow_network_clone.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/gin-gonic/gin"
@@ -24,6 +25,13 @@ type FlowNetworkClonesAPI struct {
 func (a *FlowNetworkClonesAPI) GetFlowNetworkClones(ctx *gin.Context) {
 	args := buildFlowNetworkCloneArgs(ctx)
 	q, err := a.DB.GetFlowNetworkClones(args)
+	if err == nil && args.IsMetadata {
+		var flowNetworkClonesMetaData []*interfaces.FlowNetworkCloneMetadata
+		out, _ := json.Marshal(q)
+		_ = json.Unmarshal(out, &flowNetworkClonesMetaData)
+		ResponseHandler(flowNetworkClonesMetaData, err, ctx)
+		return
+	}
 	ResponseHandler(q, err, ctx)
 }
 

--- a/database/flow_network.go
+++ b/database/flow_network.go
@@ -23,7 +23,6 @@ func (d *GormDatabase) GetFlowNetworks(args api.Args) ([]*model.FlowNetwork, err
 	query := d.buildFlowNetworkQuery(args)
 	if err := query.Find(&flowNetworksModel).Error; err != nil {
 		return nil, err
-
 	}
 	return flowNetworksModel, nil
 }

--- a/interfaces/consumer_metadata.go
+++ b/interfaces/consumer_metadata.go
@@ -1,0 +1,7 @@
+package interfaces
+
+type ConsumerMetadata struct {
+	UUID    string            `json:"uuid"`
+	Name    string            `json:"name"`
+	Writers []*WriterMetadata `json:"writers"`
+}

--- a/interfaces/flow_network_metadata.go
+++ b/interfaces/flow_network_metadata.go
@@ -8,3 +8,12 @@ type FlowNetworkMetadata struct {
 	DeviceName string            `json:"device_name"`
 	Streams    []*StreamMetadata `json:"streams"`
 }
+
+type FlowNetworkCloneMetadata struct {
+	UUID         string                 `json:"uuid"`
+	Name         string                 `json:"name"`
+	ClientName   string                 `json:"client_name"`
+	SiteName     string                 `json:"site_name"`
+	DeviceName   string                 `json:"device_name"`
+	StreamClones []*StreamCloneMetadata `json:"stream_clones"`
+}

--- a/interfaces/flow_network_metadata.go
+++ b/interfaces/flow_network_metadata.go
@@ -1,0 +1,10 @@
+package interfaces
+
+type FlowNetworkMetadata struct {
+	UUID       string            `json:"uuid"`
+	Name       string            `json:"name"`
+	ClientName string            `json:"client_name"`
+	SiteName   string            `json:"site_name"`
+	DeviceName string            `json:"device_name"`
+	Streams    []*StreamMetadata `json:"streams"`
+}

--- a/interfaces/producer_metadata.go
+++ b/interfaces/producer_metadata.go
@@ -1,0 +1,7 @@
+package interfaces
+
+type ProducerMetadata struct {
+	UUID         string                 `json:"uuid"`
+	Name         string                 `json:"name"`
+	WriterClones []*WriterCloneMetadata `json:"writer_clones"`
+}

--- a/interfaces/stream_metadata.go
+++ b/interfaces/stream_metadata.go
@@ -1,0 +1,7 @@
+package interfaces
+
+type StreamMetadata struct {
+	UUID      string              `json:"uuid"`
+	Name      string              `json:"name"`
+	Producers []*ProducerMetadata `json:"producers"`
+}

--- a/interfaces/stream_metadata.go
+++ b/interfaces/stream_metadata.go
@@ -5,3 +5,9 @@ type StreamMetadata struct {
 	Name      string              `json:"name"`
 	Producers []*ProducerMetadata `json:"producers"`
 }
+
+type StreamCloneMetadata struct {
+	UUID      string              `json:"uuid"`
+	Name      string              `json:"name"`
+	Consumers []*ConsumerMetadata `json:"consumers"`
+}

--- a/interfaces/writer_metadata.go
+++ b/interfaces/writer_metadata.go
@@ -1,0 +1,8 @@
+package interfaces
+
+type WriterCloneMetadata struct {
+	UUID             string `json:"uuid"`
+	WriterThingClass string `json:"writer_thing_class"`
+	WriterThingUUID  string `json:"writer_thing_uuid"`
+	WriterThingName  string `json:"writer_thing_name"`
+}

--- a/interfaces/writer_metadata.go
+++ b/interfaces/writer_metadata.go
@@ -6,3 +6,10 @@ type WriterCloneMetadata struct {
 	WriterThingUUID  string `json:"writer_thing_uuid"`
 	WriterThingName  string `json:"writer_thing_name"`
 }
+
+type WriterMetadata struct {
+	UUID             string `json:"uuid"`
+	WriterThingClass string `json:"writer_thing_class"`
+	WriterThingUUID  string `json:"writer_thing_uuid"`
+	WriterThingName  string `json:"writer_thing_name"`
+}


### PR DESCRIPTION
### Summary

- Metadata option for returning flow_frameworks
   - http://localhost:1660/api/flow_networks?is_metadata=true&with_streams=true&with_producers=true&with_writer_clones=true
- Metadata option for returning flow_framework_clones
   - http://localhost:1660/api/flow_network_clones?is_metadata=true&with_stream_clones=true&with_consumers=true&with_writers=true

If we include the `is_metadata` flag as `true`, it just returns metadata. So, when we pull the metadata, large data transfer won't happen between:

- Backend to wires-plat
- Backend to Grafana