### PR TITLE
added functions to set errors of children

### DIFF
--- a/api/points.go
+++ b/api/points.go
@@ -10,8 +10,9 @@ type PointDatabase interface {
 	GetPointsBulk(bulkPoints []*model.Point) ([]*model.Point, error)
 	GetPoint(uuid string, args Args) (*model.Point, error)
 	CreatePoint(body *model.Point, fromPlugin bool) (*model.Point, error)
-	UpdatePoint(uuid string, body *model.Point, fromPlugin bool) (*model.Point, error)
-	PointWrite(uuid string, body *model.PointWriter, fromPlugin bool) (*model.Point, bool, bool, bool, error)
+	UpdatePoint(uuid string, body *model.Point, fromPlugin bool, afterRealDeviceUpdate bool) (*model.Point, error)
+	PointWrite(uuid string, body *model.PointWriter, fromPlugin bool, afterRealDeviceUpdate bool) (
+		*model.Point, bool, bool, bool, error)
 	GetOnePointByArgs(args Args) (*model.Point, error)
 	DeletePoint(uuid string) (bool, error)
 	GetPointByName(networkName, deviceName, pointName string) (*model.Point, error)

--- a/build.bash
+++ b/build.bash
@@ -55,7 +55,7 @@ mkdir -p $pluginDir
 
 BUILD_ERROR=false
 
-function buildPlugin {
+function buildPlugin() {
   echo -e "${DEFAULT}BUILDING $1..."
   go build -buildmode=plugin -o $1.so $2/*.go && cp $1.so $pluginDir
   if [ $? -eq 0 ]; then
@@ -66,45 +66,57 @@ function buildPlugin {
   fi
 }
 
-pushd $dir > /dev/null
+pushd $dir >/dev/null
 
 for i in "$@"; do
   case ${i} in
-    system)
-      buildPlugin "system" plugin/nube/system ;;
-    edge28)
-      buildPlugin "edge28" plugin/nube/protocals/edge28 ;;
-    modbus)
-      buildPlugin "modbus" plugin/nube/protocals/modbus ;;
-    lora)
-      buildPlugin "lora" plugin/nube/protocals/lora ;;
-    bacnet)
-      buildPlugin "bacnet" plugin/nube/protocals/bacnetserver ;;
-    lorawan)
-      buildPlugin "lorawan" plugin/nube/protocals/lorawan ;;
-    bacnet_master)
-      buildPlugin "bacnet_master" plugin/nube/protocals/bacnetmaster ;;
-    history)
-      buildPlugin "history" plugin/nube/database/history ;;
-    influx)
-      buildPlugin "influx" plugin/nube/database/influx ;;
-    rubixio)
-      buildPlugin "rubixio" plugin/nube/protocals/rubixio ;;
-    modbusserver)
-      buildPlugin "modbusserver" plugin/nube/protocals/modbusserver ;;
-    postgres)
-      buildPlugin "postgres" plugin/nube/database/postgres ;;
+  system)
+    buildPlugin "system" plugin/nube/system
+    ;;
+  edge28)
+    buildPlugin "edge28" plugin/nube/protocals/edge28
+    ;;
+  modbus)
+    buildPlugin "modbus" plugin/nube/protocals/modbus
+    ;;
+  lora)
+    buildPlugin "lora" plugin/nube/protocals/lora
+    ;;
+  bacnetserver)
+    buildPlugin "bacnetserver" plugin/nube/protocals/bacnetserver
+    ;;
+  lorawan)
+    buildPlugin "lorawan" plugin/nube/protocals/lorawan
+    ;;
+  bacnetmaster)
+    buildPlugin "bacnetmaster" plugin/nube/protocals/bacnetmaster
+    ;;
+  history)
+    buildPlugin "history" plugin/nube/database/history
+    ;;
+  influx)
+    buildPlugin "influx" plugin/nube/database/influx
+    ;;
+  rubixio)
+    buildPlugin "rubixio" plugin/nube/protocals/rubixio
+    ;;
+  modbusserver)
+    buildPlugin "modbusserver" plugin/nube/protocals/modbusserver
+    ;;
+  postgres)
+    buildPlugin "postgres" plugin/nube/database/postgres
+    ;;
   esac
 done
 
 if [ ${BUILD_ERROR} == true ]; then
-    exit -1
+  exit 1
 fi
 
-popd > /dev/null
+popd >/dev/null
 
 if [ ${BUILD_ONLY} == true ]; then
-    exit 0
+  exit 0
 fi
 
 if [ ${PRODUCTION} == true ]; then

--- a/database/device.go
+++ b/database/device.go
@@ -62,6 +62,27 @@ func (d *GormDatabase) CreateDevice(body *model.Device) (*model.Device, error) {
 	return body, query.Error
 }
 
+// UpdateDeviceErrors will only update the CommonFault properties of the device, all other properties will not be updated. Does not update `LastOk`.
+func (d *GormDatabase) UpdateDeviceErrors(uuid string, body *model.Device) error {
+	/* I THINK THE FIRST DB CALL HERE IS NOT REQUIRED
+	var deviceModel *model.Device
+	query := d.DB.Where("uuid = ?", uuid).First(&deviceModel)
+	if query.Error != nil {
+		return nil, query.Error
+	}
+	query = d.DB.Model(&deviceModel).Select("InFault", "MessageLevel", "MessageCode", "Message", "LastFail").Updates(&body)
+	if query.Error != nil {
+		return nil, query.Error
+	}
+
+	*/
+	query := d.DB.Model(&body).Where("uuid = ?", uuid).Select("InFault", "MessageLevel", "MessageCode", "Message", "LastFail").Updates(&body)
+	if query.Error != nil {
+		return query.Error
+	}
+	return nil
+}
+
 func (d *GormDatabase) UpdateDevice(uuid string, body *model.Device, fromPlugin bool) (*model.Device, error) {
 	var deviceModel *model.Device
 	query := d.DB.Where("uuid = ?", uuid).First(&deviceModel)
@@ -86,7 +107,9 @@ func (d *GormDatabase) UpdateDevice(uuid string, body *model.Device, fromPlugin 
 			return nil, err
 		}
 	}
-	query = d.DB.Model(&deviceModel).Select("*").Updates(body)
+	query = d.DB.Model(&deviceModel).Updates(body)
+	// TODO: add boolean argument to update all properties or just non Zero Value properties.
+	// query = d.DB.Model(&deviceModel).Select("*").Updates(body)
 
 	var nModel *model.Network
 	query = d.DB.Where("uuid = ?", deviceModel.NetworkUUID).First(&nModel)

--- a/database/device.go
+++ b/database/device.go
@@ -86,7 +86,7 @@ func (d *GormDatabase) UpdateDevice(uuid string, body *model.Device, fromPlugin 
 			return nil, err
 		}
 	}
-	query = d.DB.Model(&deviceModel).Updates(body)
+	query = d.DB.Model(&deviceModel).Select("*").Updates(body)
 
 	var nModel *model.Network
 	query = d.DB.Where("uuid = ?", deviceModel.NetworkUUID).First(&nModel)

--- a/database/device.go
+++ b/database/device.go
@@ -107,9 +107,7 @@ func (d *GormDatabase) UpdateDevice(uuid string, body *model.Device, fromPlugin 
 			return nil, err
 		}
 	}
-	query = d.DB.Model(&deviceModel).Updates(body)
-	// TODO: add boolean argument to update all properties or just non Zero Value properties.
-	// query = d.DB.Model(&deviceModel).Select("*").Updates(body)
+	query = d.DB.Model(&deviceModel).Select("*").Updates(body)
 
 	var nModel *model.Network
 	query = d.DB.Where("uuid = ?", deviceModel.NetworkUUID).First(&nModel)

--- a/database/device_funcs.go
+++ b/database/device_funcs.go
@@ -56,7 +56,7 @@ func (d *GormDatabase) deviceNameExistsInNetwork(deviceName, networkUUID string)
 // SetErrorsForAllPointsOnDevice sets the fault/error properties of all points for a specific device
 // messageLevel = model.MessageLevel
 // messageCode = model.CommonFaultCode
-func (d *GormDatabase) SetErrorsForAllPointsOnDevice(deviceUUID string, message string, messageLevel string, messageCode string, fromPlugin bool) error {
+func (d *GormDatabase) SetErrorsForAllPointsOnDevice(deviceUUID string, message string, messageLevel string, messageCode string) error {
 	device, err := d.GetDevice(deviceUUID, api.Args{WithPoints: true})
 	if device != nil && err != nil {
 		return err
@@ -67,7 +67,7 @@ func (d *GormDatabase) SetErrorsForAllPointsOnDevice(deviceUUID string, message 
 		point.CommonFault.MessageCode = messageCode
 		point.CommonFault.Message = message
 		point.CommonFault.LastFail = time.Now().UTC()
-		_, err = d.UpdatePoint(point.UUID, point, fromPlugin)
+		err = d.UpdatePointErrors(point.UUID, point)
 		if err != nil {
 			log.Infof("setErrorsForAllPointsOnDevice() Error: %s\n", err.Error())
 		}
@@ -76,7 +76,7 @@ func (d *GormDatabase) SetErrorsForAllPointsOnDevice(deviceUUID string, message 
 }
 
 // ClearErrorsForAllPointsOnDevice clears the fault/error properties of all points for a specific device
-func (d *GormDatabase) ClearErrorsForAllPointsOnDevice(deviceUUID string, fromPlugin bool) error {
+func (d *GormDatabase) ClearErrorsForAllPointsOnDevice(deviceUUID string) error {
 	device, err := d.GetDevice(deviceUUID, api.Args{WithPoints: true})
 	if device != nil && err != nil {
 		return err
@@ -87,7 +87,7 @@ func (d *GormDatabase) ClearErrorsForAllPointsOnDevice(deviceUUID string, fromPl
 		point.CommonFault.MessageCode = model.CommonFaultCode.Ok
 		point.CommonFault.Message = ""
 		point.CommonFault.LastOk = time.Now().UTC()
-		_, err = d.UpdatePoint(point.UUID, point, fromPlugin)
+		err = d.UpdatePointErrors(point.UUID, point)
 		if err != nil {
 			log.Infof("clearErrorsForAllPointsOnDevice() Error: %s\n", err.Error())
 		}

--- a/database/device_funcs.go
+++ b/database/device_funcs.go
@@ -3,6 +3,8 @@ package database
 import (
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	log "github.com/sirupsen/logrus"
+	"time"
 )
 
 // GetDeviceByPoint get a device by point object
@@ -51,4 +53,44 @@ func (d *GormDatabase) deviceNameExistsInNetwork(deviceName, networkUUID string)
 	return nil, false
 }
 
-//TODO: add function to set/clear an error on all points in a device
+// SetErrorsForAllPointsOnDevice sets the fault/error properties of all points for a specific device
+// messageLevel = model.MessageLevel
+// messageCode = model.CommonFaultCode
+func (d *GormDatabase) SetErrorsForAllPointsOnDevice(deviceUUID string, message string, messageLevel string, messageCode string, fromPlugin bool) error {
+	device, err := d.GetDevice(deviceUUID, api.Args{WithPoints: true})
+	if device != nil && err != nil {
+		return err
+	}
+	for _, point := range device.Points {
+		point.CommonFault.InFault = true
+		point.CommonFault.MessageLevel = messageLevel
+		point.CommonFault.MessageCode = messageCode
+		point.CommonFault.Message = message
+		point.CommonFault.LastFail = time.Now().UTC()
+		_, err = d.UpdatePoint(point.UUID, point, fromPlugin)
+		if err != nil {
+			log.Infof("setErrorsForAllPointsOnDevice() Error: %s\n", err.Error())
+		}
+	}
+	return nil
+}
+
+// ClearErrorsForAllPointsOnDevice clears the fault/error properties of all points for a specific device
+func (d *GormDatabase) ClearErrorsForAllPointsOnDevice(deviceUUID string, fromPlugin bool) error {
+	device, err := d.GetDevice(deviceUUID, api.Args{WithPoints: true})
+	if device != nil && err != nil {
+		return err
+	}
+	for _, point := range device.Points {
+		point.CommonFault.InFault = false
+		point.CommonFault.MessageLevel = model.MessageLevel.Normal
+		point.CommonFault.MessageCode = model.CommonFaultCode.Ok
+		point.CommonFault.Message = ""
+		point.CommonFault.LastOk = time.Now().UTC()
+		_, err = d.UpdatePoint(point.UUID, point, fromPlugin)
+		if err != nil {
+			log.Infof("clearErrorsForAllPointsOnDevice() Error: %s\n", err.Error())
+		}
+	}
+	return nil
+}

--- a/database/network.go
+++ b/database/network.go
@@ -87,6 +87,27 @@ func (d *GormDatabase) CreateNetwork(body *model.Network, fromPlugin bool) (*mod
 	return body, nil
 }
 
+// UpdateNetworkErrors will only update the CommonFault properties of the network, all other properties will not be updated. Does not update `LastOk`.
+func (d *GormDatabase) UpdateNetworkErrors(uuid string, body *model.Network) error {
+	/* I THINK THE FIRST DB CALL HERE IS NOT REQUIRED
+	var networkModel *model.Network
+	query := d.DB.Where("uuid = ?", uuid).First(&networkModel)
+	if query.Error != nil {
+		return nil, query.Error
+	}
+	query = d.DB.Model(&networkModel).Select("InFault", "MessageLevel", "MessageCode", "Message", "LastFail").Updates(&body)
+	if query.Error != nil {
+		return nil, query.Error
+	}
+
+	*/
+	query := d.DB.Model(&body).Where("uuid = ?", uuid).Select("InFault", "MessageLevel", "MessageCode", "Message", "LastFail").Updates(&body)
+	if query.Error != nil {
+		return query.Error
+	}
+	return nil
+}
+
 func (d *GormDatabase) UpdateNetwork(uuid string, body *model.Network, fromPlugin bool) (*model.Network, error) {
 	var networkModel *model.Network
 	query := d.DB.Where("uuid = ?", uuid).First(&networkModel)
@@ -98,7 +119,9 @@ func (d *GormDatabase) UpdateNetwork(uuid string, body *model.Network, fromPlugi
 			return nil, err
 		}
 	}
-	query = d.DB.Model(&networkModel).Select("*").Updates(&body)
+	query = d.DB.Model(&networkModel).Updates(&body)
+	// TODO: add boolean argument to update all properties or just non Zero Value properties.
+	// query = d.DB.Model(&networkModel).Select("*").Updates(&body)
 	if query.Error != nil {
 		return nil, query.Error
 	}

--- a/database/network.go
+++ b/database/network.go
@@ -98,7 +98,7 @@ func (d *GormDatabase) UpdateNetwork(uuid string, body *model.Network, fromPlugi
 			return nil, err
 		}
 	}
-	query = d.DB.Model(&networkModel).Updates(&body)
+	query = d.DB.Model(&networkModel).Select("*").Updates(&body)
 	if query.Error != nil {
 		return nil, query.Error
 	}

--- a/database/network.go
+++ b/database/network.go
@@ -119,9 +119,7 @@ func (d *GormDatabase) UpdateNetwork(uuid string, body *model.Network, fromPlugi
 			return nil, err
 		}
 	}
-	query = d.DB.Model(&networkModel).Updates(&body)
-	// TODO: add boolean argument to update all properties or just non Zero Value properties.
-	// query = d.DB.Model(&networkModel).Select("*").Updates(&body)
+	query = d.DB.Model(&networkModel).Select("*").Updates(&body)
 	if query.Error != nil {
 		return nil, query.Error
 	}

--- a/database/network_funcs.go
+++ b/database/network_funcs.go
@@ -110,7 +110,7 @@ func (d *GormDatabase) GetNetworkByDeviceUUID(devUUID string, args api.Args) (ne
 // SetErrorsForAllDevicesOnNetwork sets the fault/error properties of all devices for a specific network. Optional to set the points of each device also.
 // messageLevel = model.MessageLevel
 // messageCode = model.CommonFaultCode
-func (d *GormDatabase) SetErrorsForAllDevicesOnNetwork(networkUUID string, message string, messageLevel string, messageCode string, doPoints bool, fromPlugin bool) error {
+func (d *GormDatabase) SetErrorsForAllDevicesOnNetwork(networkUUID string, message string, messageLevel string, messageCode string, doPoints bool) error {
 	network, err := d.GetNetwork(networkUUID, api.Args{WithDevices: true, WithPoints: doPoints})
 	if network != nil && err != nil {
 		return err
@@ -121,19 +121,19 @@ func (d *GormDatabase) SetErrorsForAllDevicesOnNetwork(networkUUID string, messa
 		device.CommonFault.MessageCode = messageCode
 		device.CommonFault.Message = message
 		device.CommonFault.LastFail = time.Now().UTC()
-		_, err = d.UpdateDevice(device.UUID, device, fromPlugin)
+		err = d.UpdateDeviceErrors(device.UUID, device)
 		if err != nil {
 			log.Infof("setErrorsForAllDevicesOnNetwork() Error: %s\n", err.Error())
 		}
 		if doPoints {
-			err = d.SetErrorsForAllPointsOnDevice(device.UUID, message, messageLevel, messageCode, fromPlugin)
+			err = d.SetErrorsForAllPointsOnDevice(device.UUID, message, messageLevel, messageCode)
 		}
 	}
 	return nil
 }
 
 // ClearErrorsForAllDevicesOnNetwork clears the fault/error properties of all devices for a specific network. Optional to clear the points of each device also.
-func (d *GormDatabase) ClearErrorsForAllDevicesOnNetwork(networkUUID string, doPoints bool, fromPlugin bool) error {
+func (d *GormDatabase) ClearErrorsForAllDevicesOnNetwork(networkUUID string, doPoints bool) error {
 	network, err := d.GetNetwork(networkUUID, api.Args{WithDevices: true, WithPoints: doPoints})
 	if network != nil && err != nil {
 		return err
@@ -144,12 +144,12 @@ func (d *GormDatabase) ClearErrorsForAllDevicesOnNetwork(networkUUID string, doP
 		device.CommonFault.MessageCode = model.CommonFaultCode.Ok
 		device.CommonFault.Message = ""
 		device.CommonFault.LastOk = time.Now().UTC()
-		_, err = d.UpdateDevice(device.UUID, device, fromPlugin)
+		err = d.UpdateDeviceErrors(device.UUID, device)
 		if err != nil {
 			log.Infof("clearErrorsForAllDevicesOnNetwork() Error: %s\n", err.Error())
 		}
 		if doPoints {
-			err = d.ClearErrorsForAllPointsOnDevice(device.UUID, fromPlugin)
+			err = d.ClearErrorsForAllPointsOnDevice(device.UUID)
 		}
 	}
 	return nil

--- a/database/point.go
+++ b/database/point.go
@@ -152,7 +152,7 @@ func (d *GormDatabase) UpdatePoint(uuid string, body *model.Point, fromPlugin bo
 		// nil is ignored on GORM, so we are pushing forcefully because fallback is nullable field
 		d.DB.Model(&pointModel).Update("fallback", nil)
 	}
-	query = d.DB.Model(&pointModel).Updates(&body)
+	query = d.DB.Model(&pointModel).Select("*").Updates(&body)
 
 	//TODO: we need to decide if a read only point needs to have a priority array or if it should just be nil.
 	if body.Priority == nil {
@@ -262,7 +262,7 @@ func (d *GormDatabase) UpdatePointValue(pointModel *model.Point, priority *map[s
 	}
 
 	if isChange {
-		_ = d.DB.Model(&pointModel).Updates(&pointModel)
+		_ = d.DB.Model(&pointModel).Select("*").Updates(&pointModel)
 		err = d.ProducersPointWrite(pointModel.UUID, priority, pointModel.PresentValue, isPresentValueChange)
 		if err != nil {
 			return nil, false, false, false, err

--- a/database/point.go
+++ b/database/point.go
@@ -53,6 +53,44 @@ func (d *GormDatabase) GetPoint(uuid string, args api.Args) (*model.Point, error
 	return pointModel, nil
 }
 
+func (d *GormDatabase) GetPointByName(networkName, deviceName, pointName string) (*model.Point, error) {
+	var pointModel *model.Point
+	net, err := d.GetNetworkByName(networkName, api.Args{WithDevices: true, WithPoints: true})
+	if err != nil {
+		return nil, errors.New("failed to find a network with that name")
+	}
+	deviceExist := false
+	pointExist := false
+	for _, device := range net.Devices {
+		if device.Name == deviceName {
+			deviceExist = true
+			for _, p := range device.Points {
+				if p.Name == pointName {
+					pointExist = true
+					pointModel = p
+					break
+				}
+			}
+		}
+	}
+	if !deviceExist {
+		return nil, errors.New("failed to find a device with that name")
+	}
+	if !pointExist {
+		return nil, errors.New("found device but failed to find a point with that name")
+	}
+	return pointModel, nil
+}
+
+func (d *GormDatabase) GetOnePointByArgs(args api.Args) (*model.Point, error) {
+	var pointModel *model.Point
+	query := d.buildPointQuery(args)
+	if err := query.First(&pointModel).Error; err != nil {
+		return nil, err
+	}
+	return pointModel, nil
+}
+
 func (d *GormDatabase) CreatePoint(body *model.Point, fromPlugin bool) (*model.Point, error) {
 	body.UUID = nuuid.MakeTopicUUID(model.ThingClass.Point)
 	body.Name = nameIsNil(body.Name)
@@ -115,7 +153,8 @@ func (d *GormDatabase) CreatePoint(body *model.Point, fromPlugin bool) (*model.P
 	return body, err
 }
 
-func (d *GormDatabase) UpdatePoint(uuid string, body *model.Point, fromPlugin bool) (*model.Point, error) {
+func (d *GormDatabase) UpdatePoint(uuid string, body *model.Point, fromPlugin bool, afterRealDeviceUpdate bool) (
+	*model.Point, error) {
 	var pointModel *model.Point
 	query := d.DB.Where("uuid = ?", uuid).Preload("Priority").First(&pointModel)
 	if query.Error != nil {
@@ -138,6 +177,7 @@ func (d *GormDatabase) UpdatePoint(uuid string, body *model.Point, fromPlugin bo
 			return nil, err
 		}
 	}
+	query = d.DB.Model(&pointModel).Select("*").Updates(&body)
 
 	// TODO: we need to decide if a read only point needs to have a priority array or if it should just be nil.
 	if body.Priority == nil {
@@ -147,31 +187,35 @@ func (d *GormDatabase) UpdatePoint(uuid string, body *model.Point, fromPlugin bo
 	}
 
 	priorityMap := priorityarray.ConvertToMap(*pointModel.Priority)
-	pnt, _, _, _, err := d.updatePointValue(pointModel, &priorityMap, fromPlugin)
+	pnt, _, _, _, err := d.updatePointValue(pointModel, &priorityMap, fromPlugin, afterRealDeviceUpdate)
+
 	if err != nil {
 		return nil, err
 	}
 	return pnt, nil
 }
 
-func (d *GormDatabase) PointWrite(uuid string, body *model.PointWriter, fromPlugin bool) (
+func (d *GormDatabase) PointWrite(uuid string, body *model.PointWriter, fromPlugin bool, afterRealDeviceUpdate bool) (
 	returnPoint *model.Point, isPresentValueChange, isWriteValueChange, isPriorityChanged bool, err error) {
 	var pointModel *model.Point
 	query := d.DB.Where("uuid = ?", uuid).Preload("Priority").First(&pointModel)
 	if query.Error != nil {
 		return nil, false, false, false, query.Error
 	}
-	if body.Priority == nil {
-		return nil, false, false, false, errors.New("no priority value is been sent")
+	if body == nil || body.Priority == nil {
+		return nil, false, false, false,
+			errors.New("no priority value is been sent")
 	} else {
 		pointModel.ValueUpdatedFlag = boolean.NewTrue()
 	}
-	point, isPresentValueChange, isWriteValueChange, isPriorityChanged, err := d.updatePointValue(pointModel, body.Priority, fromPlugin)
+	point, isPresentValueChange, isWriteValueChange, isPriorityChanged, err :=
+		d.updatePointValue(pointModel, body.Priority, fromPlugin, afterRealDeviceUpdate)
 	return point, isPresentValueChange, isWriteValueChange, isPriorityChanged, err
 }
 
-func (d *GormDatabase) updatePointValue(pointModel *model.Point, priority *map[string]*float64, fromPlugin bool) (
-	returnPoint *model.Point, isPresentValueChange, isWriteValueChange, isPriorityChanged bool, err error) {
+func (d *GormDatabase) updatePointValue(pointModel *model.Point, priority *map[string]*float64, fromPlugin bool,
+	afterRealDeviceUpdate bool) (returnPoint *model.Point, isPresentValueChange, isWriteValueChange,
+	isPriorityChanged bool, err error) {
 	if pointModel.PointPriorityArrayMode == "" {
 		pointModel.PointPriorityArrayMode = model.PriorityArrayToPresentValue // sets default priority array mode
 	}
@@ -184,11 +228,13 @@ func (d *GormDatabase) updatePointValue(pointModel *model.Point, priority *map[s
 	presentValue = pointScale(presentValue, pointModel.ScaleInMin, pointModel.ScaleInMax, pointModel.ScaleOutMin, pointModel.ScaleOutMax)
 	presentValue = pointRange(presentValue, pointModel.LimitMin, pointModel.LimitMax)
 	eval, err := pointEval(presentValue, pointModel.MathOnPresentValue)
-	pointModel.CommonFault.InFault = false
-	pointModel.CommonFault.MessageLevel = model.MessageLevel.Info
-	pointModel.CommonFault.MessageCode = model.CommonFaultCode.PointWriteOk
-	pointModel.CommonFault.Message = fmt.Sprintf("last-updated: %s", utilstime.TimeStamp())
-	pointModel.CommonFault.LastOk = time.Now().UTC()
+	if afterRealDeviceUpdate {
+		pointModel.CommonFault.InFault = false
+		pointModel.CommonFault.MessageLevel = model.MessageLevel.Info
+		pointModel.CommonFault.MessageCode = model.CommonFaultCode.PointWriteOk
+		pointModel.CommonFault.Message = fmt.Sprintf("last-updated: %s", utilstime.TimeStamp())
+		pointModel.CommonFault.LastOk = time.Now().UTC()
+	}
 	if err != nil {
 		log.Errorln("point.db updatePointValue() error on run point MathOnPresentValue error:", err)
 		pointModel.CommonFault.InFault = true
@@ -215,13 +261,14 @@ func (d *GormDatabase) updatePointValue(pointModel *model.Point, priority *map[s
 	// example for wires and modbus:
 	// if a new value is written from wires then set this to false so the modbus knows on the next poll to write a new
 	// value to the modbus point
-	if !fromPlugin {
-		pointModel.InSync = boolean.NewFalse()
-		pointModel.WritePollRequired = boolean.NewTrue()
-	} else {
+	if fromPlugin && afterRealDeviceUpdate {
 		pointModel.InSync = boolean.NewTrue()
 		pointModel.WritePollRequired = boolean.NewFalse()
+	} else {
+		pointModel.InSync = boolean.NewFalse()
+		pointModel.WritePollRequired = boolean.NewTrue() // TODO: make sure making this writable won't effect
 	}
+
 	if !integer.IsUnit32Nil(pointModel.Decimal) && presentValue != nil {
 		val := nmath.RoundTo(*presentValue, *pointModel.Decimal)
 		presentValue = &val
@@ -314,4 +361,17 @@ func (d *GormDatabase) DeletePoint(uuid string) (bool, error) {
 		}
 		return true, nil
 	}
+}
+
+func (d *GormDatabase) PointWriteByName(networkName, deviceName, pointName string, body *model.PointWriter,
+	fromPlugin bool) (*model.Point, error) {
+	point, err := d.GetPointByName(networkName, deviceName, pointName)
+	if err != nil {
+		return nil, err
+	}
+	write, _, _, _, err := d.PointWrite(point.UUID, body, fromPlugin, false)
+	if err != nil {
+		return nil, err
+	}
+	return write, nil
 }

--- a/database/point.go
+++ b/database/point.go
@@ -173,9 +173,7 @@ func (d *GormDatabase) UpdatePoint(uuid string, body *model.Point, fromPlugin bo
 		// nil is ignored on GORM, so we are pushing forcefully because fallback is nullable field
 		d.DB.Model(&pointModel).Update("fallback", nil)
 	}
-	query = d.DB.Model(&pointModel).Updates(&body)
-	// TODO: add boolean argument to update all properties or just non Zero Value properties.
-	//query = d.DB.Model(&pointModel).Select("*").Updates(&body)
+	query = d.DB.Model(&pointModel).Select("*").Updates(&body)
 
 	//TODO: we need to decide if a read only point needs to have a priority array or if it should just be nil.
 	if body.Priority == nil {
@@ -288,9 +286,7 @@ func (d *GormDatabase) UpdatePointValue(pointModel *model.Point, priority *map[s
 	}
 
 	if isChange {
-		_ = d.DB.Model(&pointModel).Updates(&pointModel)
-		// TODO: add boolean argument to update all properties or just non Zero Value properties.
-		//_ = d.DB.Model(&pointModel).Select("*").Updates(&pointModel)
+		_ = d.DB.Model(&pointModel).Select("*").Updates(&pointModel)
 		err = d.ProducersPointWrite(pointModel.UUID, priority, pointModel.PresentValue, isPresentValueChange)
 		if err != nil {
 			return nil, false, false, false, err

--- a/database/point_funcs.go
+++ b/database/point_funcs.go
@@ -1,9 +1,7 @@
 package database
 
 import (
-	"errors"
 	"fmt"
-	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/flow-framework/utils/boolean"
 	"github.com/NubeIO/flow-framework/utils/float"
 	"github.com/NubeIO/flow-framework/utils/integer"
@@ -12,57 +10,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"strings"
 )
-
-func (d *GormDatabase) GetPointByName(networkName, deviceName, pointName string) (*model.Point, error) {
-	var pointModel *model.Point
-	net, err := d.GetNetworkByName(networkName, api.Args{WithDevices: true, WithPoints: true})
-	if err != nil {
-		return nil, errors.New("failed to find a network with that name")
-	}
-	deviceExist := false
-	pointExist := false
-	for _, device := range net.Devices {
-		if device.Name == deviceName {
-			deviceExist = true
-			for _, p := range device.Points {
-				if p.Name == pointName {
-					pointExist = true
-					pointModel = p
-					break
-				}
-			}
-		}
-	}
-	if !deviceExist {
-		return nil, errors.New("failed to find a device with that name")
-	}
-	if !pointExist {
-		return nil, errors.New("found device but failed to find a point with that name")
-	}
-	return pointModel, nil
-}
-
-// PointWriteByName TODO: functions calling  d.PointWrite(point.UUID, body, fromPlugin) should be routed via plugin!!
-func (d *GormDatabase) PointWriteByName(networkName, deviceName, pointName string, body *model.PointWriter, fromPlugin bool) (*model.Point, error) {
-	point, err := d.GetPointByName(networkName, deviceName, pointName)
-	if err != nil {
-		return nil, err
-	}
-	write, _, _, _, err := d.PointWrite(point.UUID, body, fromPlugin)
-	if err != nil {
-		return nil, err
-	}
-	return write, nil
-}
-
-func (d *GormDatabase) GetOnePointByArgs(args api.Args) (*model.Point, error) {
-	var pointModel *model.Point
-	query := d.buildPointQuery(args)
-	if err := query.First(&pointModel).Error; err != nil {
-		return nil, err
-	}
-	return pointModel, nil
-}
 
 // updatePriority it updates priority array of point model
 // it attaches the point model fields values for updating it on it's parent function

--- a/database/point_plugin.go
+++ b/database/point_plugin.go
@@ -18,7 +18,7 @@ func (d *GormDatabase) CreatePointPlugin(body *model.Point) (point *model.Point,
 		if err != nil {
 			return nil, err
 		}
-		point, err = d.UpdatePoint(point.UUID, point, false)
+		point, err = d.UpdatePoint(point.UUID, point, false, false)
 		return
 	}
 	body.CommonFault.MessageLevel = model.MessageLevel.NoneCritical
@@ -43,7 +43,7 @@ func (d *GormDatabase) UpdatePointPlugin(uuid string, body *model.Point) (point 
 	}
 	pluginName := network.PluginPath
 	if pluginName == "system" {
-		point, err = d.UpdatePoint(uuid, body, false)
+		point, err = d.UpdatePoint(uuid, body, false, false)
 		if err != nil {
 			return nil, err
 		}
@@ -64,7 +64,7 @@ func (d *GormDatabase) WritePointPlugin(uuid string, body *model.PointWriter) (p
 	}
 	pluginName := network.PluginPath
 	if pluginName == "system" {
-		point, _, _, _, err = d.PointWrite(uuid, body, false)
+		point, _, _, _, err = d.PointWrite(uuid, body, false, false)
 		if err != nil {
 			return nil, err
 		}

--- a/database/sync_writer.go
+++ b/database/sync_writer.go
@@ -50,7 +50,7 @@ func (d *GormDatabase) SyncCOV(writerUUID string, body *model.SyncCOV) error {
 		pointModel := model.PointWriter{
 			Priority: body.Priority,
 		}
-		_, _, _, _, err = d.PointWrite(uuid, &pointModel, false)
+		_, _, _, _, err = d.PointWrite(uuid, &pointModel, false, false)
 		return err
 	} else {
 		return d.ScheduleWrite(writer.WriterThingUUID, body.Schedule)
@@ -72,7 +72,7 @@ func (d *GormDatabase) SyncWriterWriteAction(sourceUUID string, body *model.Sync
 		pointWriter := model.PointWriter{Priority: body.Priority}
 		// TODO: change this section by below commented section
 		producer, _ := d.GetProducer(writerClone.ProducerUUID, api.Args{})
-		_, _, _, _, err = d.PointWrite(producer.ProducerThingUUID, &pointWriter, false)
+		_, _, _, _, err = d.PointWrite(producer.ProducerThingUUID, &pointWriter, false, false)
 		// Currently, writerClone.WriterThingUUID has not valid `WriterThingUUID` on old deployments
 		// _, err = d.PointWrite(writerClone.WriterThingUUID, &point, true)
 		return err

--- a/plugin/nube/protocals/bacnetmaster/api.go
+++ b/plugin/nube/protocals/bacnetmaster/api.go
@@ -65,7 +65,7 @@ func (inst *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 	})
 	mux.PATCH(plugin.PointsURL, func(ctx *gin.Context) {
 		body, _ := plugin.GetBODYPoint(ctx)
-		point, err := inst.updatePoint(body)
+		point, err := inst.db.UpdatePoint(body.UUID, body, true, false)
 		api.ResponseHandler(point, err, ctx)
 	})
 	mux.PATCH(plugin.PointsWriteURL, func(ctx *gin.Context) {

--- a/plugin/nube/protocals/bacnetmaster/app.go
+++ b/plugin/nube/protocals/bacnetmaster/app.go
@@ -81,15 +81,6 @@ func (inst *Instance) updateDevice(body *model.Device) (device *model.Device, er
 	return device, nil
 }
 
-// updatePoint update point
-func (inst *Instance) updatePoint(body *model.Point) (point *model.Point, err error) {
-	point, err = inst.db.UpdatePoint(body.UUID, body, true)
-	if err != nil {
-		return nil, err
-	}
-	return point, nil
-}
-
 // deleteNetwork delete network
 func (inst *Instance) deleteNetwork(body *model.Network) (ok bool, err error) {
 	ok, err = inst.db.DeleteNetwork(body.UUID)
@@ -102,15 +93,8 @@ func (inst *Instance) deleteNetwork(body *model.Network) (ok bool, err error) {
 
 // writePoint update point. Called via API call.
 func (inst *Instance) writePoint(pntUUID string, body *model.PointWriter) (point *model.Point, err error) {
-	// TODO: check for PointWriteByName calls that might not flow through the plugin.
-	if body == nil {
-		return
-	}
-	point, _, _, _, err = inst.db.WritePoint(pntUUID, body, true)
-	if err != nil || point == nil {
-		return nil, err
-	}
-	return point, nil
+	point, _, _, _, err = inst.db.PointWrite(pntUUID, body, false)
+	return point, err
 }
 
 // deleteNetwork delete device

--- a/plugin/nube/protocals/bacnetmaster/app.go
+++ b/plugin/nube/protocals/bacnetmaster/app.go
@@ -167,7 +167,7 @@ func (inst *Instance) pointUpdateValue(uuid string, value float64) (*model.Point
 }
 
 // pointUpdate update point present value
-func (inst *Instance) pointUpdateErr(uuid string, err error) (*model.Point, error) {
+func (inst *Instance) pointUpdateErr(uuid string, err error) error {
 	var point model.Point
 	point.CommonFault.InFault = true
 	point.CommonFault.MessageLevel = model.MessageLevel.Fail
@@ -178,7 +178,7 @@ func (inst *Instance) pointUpdateErr(uuid string, err error) (*model.Point, erro
 	_, err = inst.db.UpdatePoint(uuid, &point, true)
 	if err != nil {
 		log.Error("bacnet-master: pointUpdateErr()", err)
-		return nil, err
+		return err
 	}
-	return nil, nil
+	return nil
 }

--- a/plugin/nube/protocals/bacnetmaster/polling.go
+++ b/plugin/nube/protocals/bacnetmaster/polling.go
@@ -72,7 +72,7 @@ func (inst *Instance) polling(p polling) error {
 						if pnt.WriteMode == "read_only" || pnt.WriteMode == "" {
 							readFloat, err := inst.doReadValue(pnt, net.UUID, dev.UUID)
 							if err != nil {
-								_, err = inst.pointUpdateErr(pnt.UUID, err)
+								err = inst.pointUpdateErr(pnt.UUID, err)
 								continue
 							} else {
 								_, err := inst.pointUpdateValue(pnt.UUID, readFloat)
@@ -100,7 +100,7 @@ func (inst *Instance) polling(p polling) error {
 							if doWrite {
 								err := inst.doWrite(pnt, net.UUID, dev.UUID)
 								if err != nil {
-									_, err = inst.pointUpdateErr(pnt.UUID, err)
+									err = inst.pointUpdateErr(pnt.UUID, err)
 									continue
 								}
 								// val := float.NonNil(pnt.WriteValue) //TODO not sure is this should then update the PV of the point

--- a/plugin/nube/protocals/bacnetmaster/polling.go
+++ b/plugin/nube/protocals/bacnetmaster/polling.go
@@ -75,7 +75,7 @@ func (inst *Instance) polling(p polling) error {
 								err = inst.pointUpdateErr(pnt.UUID, err)
 								continue
 							} else {
-								_, err := inst.pointUpdateValue(pnt.UUID, readFloat)
+								err := inst.pointWrite(pnt.UUID, readFloat)
 								if err != nil {
 									continue
 								}
@@ -104,7 +104,7 @@ func (inst *Instance) polling(p polling) error {
 									continue
 								}
 								// val := float.NonNil(pnt.WriteValue) //TODO not sure is this should then update the PV of the point
-								_, err = inst.pointUpdate(pnt.UUID)
+								err = inst.pointUpdateSuccess(pnt.UUID)
 								if err != nil {
 									continue
 								}

--- a/plugin/nube/protocals/bacnetserver/api.go
+++ b/plugin/nube/protocals/bacnetserver/api.go
@@ -60,7 +60,7 @@ func (inst *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 	})
 	mux.PATCH(plugin.PointsURL, func(ctx *gin.Context) {
 		body, _ := plugin.GetBODYPoint(ctx)
-		point, err := inst.updatePoint(body)
+		point, err := inst.db.UpdatePoint(body.UUID, body, true, false)
 		api.ResponseHandler(point, err, ctx)
 	})
 	mux.PATCH(plugin.PointsWriteURL, func(ctx *gin.Context) {

--- a/plugin/nube/protocals/bacnetserver/app.go
+++ b/plugin/nube/protocals/bacnetserver/app.go
@@ -161,42 +161,34 @@ func (inst *Instance) deletePoint(body *model.Point) (ok bool, err error) {
 	return ok, nil
 }
 
-// pointUpdate update point present value
-func (inst *Instance) pointUpdate(uuid string) (*model.Point, error) {
-	var point model.Point
-	point.CommonFault.InFault = false
-	point.CommonFault.MessageLevel = model.MessageLevel.Info
-	point.CommonFault.MessageCode = model.CommonFaultCode.PointWriteOk
-	point.CommonFault.Message = fmt.Sprintf("last-updated: %s", utilstime.TimeStamp())
-	point.CommonFault.LastOk = time.Now().UTC()
-	point.InSync = boolean.NewTrue()
-	_, err := inst.db.UpdatePoint(uuid, &point, true)
-	if err != nil {
-		log.Error("bacnet-server: UpdatePoint()", err)
-		return nil, err
-	}
-	return nil, nil
-}
-
-// pointUpdate update point present value
-func (inst *Instance) pointUpdateValue(uuid string, value float64) (*model.Point, error) {
-	var point model.Point
-	point.CommonFault.InFault = false
-	point.CommonFault.MessageLevel = model.MessageLevel.Info
-	point.CommonFault.MessageCode = model.CommonFaultCode.PointWriteOk
-	point.CommonFault.Message = fmt.Sprintf("last-updated: %s", utilstime.TimeStamp())
-	point.CommonFault.LastOk = time.Now().UTC()
+// pointWrite update point present value
+func (inst *Instance) pointWrite(uuid string, value float64) error {
 	priority := map[string]*float64{"_16": &value}
-	point.InSync = boolean.NewTrue()
-	_, _, _, _, err := inst.db.UpdatePointValue(uuid, &point, &priority, true)
+	pointWriter := model.PointWriter{Priority: &priority}
+	_, _, _, _, err := inst.db.PointWrite(uuid, &pointWriter, true)
 	if err != nil {
-		log.Error("bacnet-server: pointUpdateValue()", err)
-		return nil, err
+		log.Error("bacnet-server: pointWrite()", err)
 	}
-	return nil, nil
+	return err
 }
 
-// pointUpdate update point present value
+// pointUpdateSuccess update point present value
+func (inst *Instance) pointUpdateSuccess(uuid string) error {
+	var point model.Point
+	point.CommonFault.InFault = false
+	point.CommonFault.MessageLevel = model.MessageLevel.Info
+	point.CommonFault.MessageCode = model.CommonFaultCode.PointWriteOk
+	point.CommonFault.Message = fmt.Sprintf("last-updated: %s", utilstime.TimeStamp())
+	point.CommonFault.LastOk = time.Now().UTC()
+	point.InSync = boolean.NewTrue()
+	err := inst.db.UpdatePointErrors(uuid, &point)
+	if err != nil {
+		log.Error("bacnet-server: pointUpdateSuccess()", err)
+	}
+	return err
+}
+
+// pointUpdateErr update point present value
 func (inst *Instance) pointUpdateErr(uuid string, err error) error {
 	var point model.Point
 	point.CommonFault.InFault = true
@@ -208,7 +200,6 @@ func (inst *Instance) pointUpdateErr(uuid string, err error) error {
 	err = inst.db.UpdatePointErrors(uuid, &point)
 	if err != nil {
 		log.Error("bacnet-server: pointUpdateErr()", err)
-		return err
 	}
-	return nil
+	return err
 }

--- a/plugin/nube/protocals/bacnetserver/app.go
+++ b/plugin/nube/protocals/bacnetserver/app.go
@@ -107,15 +107,6 @@ func (inst *Instance) updateDevice(body *model.Device) (device *model.Device, er
 	return device, nil
 }
 
-// updatePoint update point
-func (inst *Instance) updatePoint(body *model.Point) (point *model.Point, err error) {
-	point, err = inst.db.UpdatePoint(body.UUID, body, true)
-	if err != nil {
-		return nil, err
-	}
-	return point, nil
-}
-
 func (inst *Instance) getNetworks() ([]*model.Network, error) {
 	return inst.db.GetNetworks(api.Args{})
 }
@@ -132,15 +123,8 @@ func (inst *Instance) deleteNetwork(body *model.Network) (ok bool, err error) {
 
 // writePoint update point. Called via API call.
 func (inst *Instance) writePoint(pntUUID string, body *model.PointWriter) (point *model.Point, err error) {
-	// TODO: check for PointWriteByName calls that might not flow through the plugin.
-	if body == nil {
-		return
-	}
-	point, _, _, _, err = inst.db.WritePoint(pntUUID, body, true)
-	if err != nil || point == nil {
-		return nil, err
-	}
-	return point, nil
+	point, _, _, _, err = inst.db.PointWrite(pntUUID, body, false)
+	return point, err
 }
 
 // deleteNetwork delete device

--- a/plugin/nube/protocals/bacnetserver/app.go
+++ b/plugin/nube/protocals/bacnetserver/app.go
@@ -197,7 +197,7 @@ func (inst *Instance) pointUpdateValue(uuid string, value float64) (*model.Point
 }
 
 // pointUpdate update point present value
-func (inst *Instance) pointUpdateErr(uuid string, err error) (*model.Point, error) {
+func (inst *Instance) pointUpdateErr(uuid string, err error) error {
 	var point model.Point
 	point.CommonFault.InFault = true
 	point.CommonFault.MessageLevel = model.MessageLevel.Fail
@@ -205,10 +205,10 @@ func (inst *Instance) pointUpdateErr(uuid string, err error) (*model.Point, erro
 	point.CommonFault.Message = fmt.Sprintf("error-time: %s msg:%s", utilstime.TimeStamp(), err.Error())
 	point.CommonFault.LastFail = time.Now().UTC()
 	point.InSync = boolean.NewFalse()
-	_, err = inst.db.UpdatePoint(uuid, &point, true)
+	err = inst.db.UpdatePointErrors(uuid, &point)
 	if err != nil {
 		log.Error("bacnet-server: pointUpdateErr()", err)
-		return nil, err
+		return err
 	}
-	return nil, nil
+	return nil
 }

--- a/plugin/nube/protocals/bacnetserver/polling.go
+++ b/plugin/nube/protocals/bacnetserver/polling.go
@@ -76,7 +76,7 @@ func (inst *Instance) polling(p polling) error {
 								err = inst.pointUpdateErr(pnt.UUID, err)
 								continue
 							} else {
-								_, err := inst.pointUpdateValue(pnt.UUID, readFloat)
+								err := inst.pointWrite(pnt.UUID, readFloat)
 								if err != nil {
 									continue
 								}
@@ -105,7 +105,7 @@ func (inst *Instance) polling(p polling) error {
 									continue
 								}
 								// val := float.NonNil(pnt.WriteValue) //TODO not sure is this should then update the PV of the point
-								_, err = inst.pointUpdate(pnt.UUID)
+								err = inst.pointUpdateSuccess(pnt.UUID)
 								if err != nil {
 									continue
 								}

--- a/plugin/nube/protocals/bacnetserver/polling.go
+++ b/plugin/nube/protocals/bacnetserver/polling.go
@@ -73,7 +73,7 @@ func (inst *Instance) polling(p polling) error {
 						if pnt.WriteMode == "read_only" {
 							readFloat, err := inst.doReadValue(pnt, net.UUID, dev.UUID)
 							if err != nil {
-								_, err = inst.pointUpdateErr(pnt.UUID, err)
+								err = inst.pointUpdateErr(pnt.UUID, err)
 								continue
 							} else {
 								_, err := inst.pointUpdateValue(pnt.UUID, readFloat)
@@ -101,7 +101,7 @@ func (inst *Instance) polling(p polling) error {
 							if doWrite {
 								err := inst.doWrite(pnt, net.UUID, dev.UUID)
 								if err != nil {
-									_, err = inst.pointUpdateErr(pnt.UUID, err)
+									err = inst.pointUpdateErr(pnt.UUID, err)
 									continue
 								}
 								// val := float.NonNil(pnt.WriteValue) //TODO not sure is this should then update the PV of the point

--- a/plugin/nube/protocals/edge28/app.go
+++ b/plugin/nube/protocals/edge28/app.go
@@ -286,7 +286,7 @@ func (inst *Instance) pointUpdate(point *model.Point, value float64, writeSucces
 }
 
 // pointUpdateErr update point with errors. Called from within plugin.
-func (inst *Instance) pointUpdateErr(point *model.Point, err error) (*model.Point, error) {
+func (inst *Instance) pointUpdateErr(point *model.Point, err error) error {
 	point.CommonFault.InFault = true
 	point.CommonFault.MessageLevel = model.MessageLevel.Fail
 	point.CommonFault.MessageCode = model.CommonFaultCode.PointError
@@ -295,7 +295,7 @@ func (inst *Instance) pointUpdateErr(point *model.Point, err error) (*model.Poin
 	_, err = inst.db.UpdatePoint(point.UUID, point, true)
 	if err != nil {
 		inst.edge28DebugMsg(" pointUpdateErr()", err)
-		return nil, err
+		return err
 	}
-	return nil, nil
+	return nil
 }

--- a/plugin/nube/protocals/edge28/app.go
+++ b/plugin/nube/protocals/edge28/app.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/NubeIO/flow-framework/api"
-	"github.com/NubeIO/flow-framework/utils/boolean"
 	"github.com/NubeIO/flow-framework/utils/float"
 	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/nils"
-	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/times/utilstime"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"time"
 )
@@ -168,13 +166,11 @@ func (inst *Instance) updatePoint(body *model.Point) (point *model.Point, err er
 	inst.edge28DebugMsg(fmt.Sprintf("updatePoint() body: %+v\n", body))
 	inst.edge28DebugMsg(fmt.Sprintf("updatePoint() priority: %+v\n", body.Priority))
 
-	point, err = inst.db.UpdatePoint(body.UUID, body, true)
+	point, err = inst.db.UpdatePoint(body.UUID, body, true, false)
 	if err != nil || point == nil {
 		inst.edge28DebugMsg("updatePoint(): bad response from UpdatePoint()")
-		return nil, err
 	}
-
-	return point, nil
+	return point, err
 }
 
 // writePoint update point. Called via API call.
@@ -188,7 +184,7 @@ func (inst *Instance) writePoint(pntUUID string, body *model.PointWriter) (point
 		return
 	}
 
-	//TODO: add code to check through priority array and limit the values by IoType.
+	// TODO: add code to check through priority array and limit the values by IoType.
 	pnt, err := inst.db.GetPoint(pntUUID, api.Args{})
 	if err == nil {
 		body.Priority = limitPriorityArrayByEdge28Type(pnt.IoType, body)
@@ -209,10 +205,9 @@ func (inst *Instance) writePoint(pntUUID string, body *model.PointWriter) (point
 
 	// body.WritePollRequired = utils.NewTrue() // TODO: commented out this section, seems like useless
 
-	point, _, _, _, err = inst.db.WritePoint(pntUUID, body, true)
-	if err != nil || point == nil {
+	point, _, _, _, err = inst.db.PointWrite(pntUUID, body, false)
+	if err != nil {
 		inst.edge28DebugMsg("writePoint(): bad response from WritePoint(), ", err)
-		return nil, err
 	}
 	return point, nil
 }
@@ -260,24 +255,11 @@ func (inst *Instance) deletePoint(body *model.Point) (ok bool, err error) {
 }
 
 // pointUpdate update point. Called from within plugin.
-func (inst *Instance) pointUpdate(point *model.Point, value float64, writeSuccess, readSuccess, clearFaults bool) (*model.Point, error) {
-	if clearFaults {
-		point.CommonFault.InFault = false
-		point.CommonFault.MessageLevel = model.MessageLevel.Info
-		point.CommonFault.MessageCode = model.CommonFaultCode.Ok
-		point.CommonFault.Message = fmt.Sprintf("last-update: %s", utilstime.TimeStamp())
-		point.CommonFault.LastOk = time.Now().UTC()
-	}
-
+func (inst *Instance) pointUpdate(point *model.Point, value float64, readSuccess bool) (*model.Point, error) {
 	if readSuccess {
-		if value != float.NonNil(point.OriginalValue) {
-			point.ValueUpdatedFlag = boolean.NewTrue() // Flag so that UpdatePointValue() will broadcast new value to producers. TODO: MAY NOT BE NEEDED.
-		}
 		point.OriginalValue = float.New(value)
 	}
-	point.InSync = boolean.NewTrue() // TODO: MAY NOT BE NEEDED.
-
-	_, err = inst.db.UpdatePoint(point.UUID, point, true)
+	_, err = inst.db.UpdatePoint(point.UUID, point, true, true)
 	if err != nil {
 		inst.edge28DebugMsg("EDGE28 UPDATE POINT UpdatePointPresentValue() error: ", err)
 		return nil, err
@@ -292,7 +274,7 @@ func (inst *Instance) pointUpdateErr(point *model.Point, err error) error {
 	point.CommonFault.MessageCode = model.CommonFaultCode.PointError
 	point.CommonFault.Message = err.Error()
 	point.CommonFault.LastFail = time.Now().UTC()
-	_, err = inst.db.UpdatePoint(point.UUID, point, true)
+	err = inst.db.UpdatePointErrors(point.UUID, point)
 	if err != nil {
 		inst.edge28DebugMsg(" pointUpdateErr()", err)
 		return err

--- a/plugin/nube/protocals/edge28/polling.go
+++ b/plugin/nube/protocals/edge28/polling.go
@@ -42,7 +42,7 @@ func (inst *Instance) Edge28Polling() error {
 	f := func() (bool, error) {
 		counter++
 		time.Sleep(time.Duration(inst.config.PollRate) * time.Second)
-		//fmt.Println("\n \n")
+		// fmt.Println("\n \n")
 		inst.edge28DebugMsg("LOOP COUNT: ", counter)
 
 		nets, err := inst.db.GetNetworksByPlugin(inst.pluginUUID, arg)
@@ -210,7 +210,7 @@ func (inst *Instance) processWrite(pnt *model.Point, value float64, rest *edgere
 				inst.pointUpdateErr(pnt, err)
 				return 0, err
 			} else {
-				_, err = inst.pointUpdate(pnt, writeValue, true, true, true)
+				_, err = inst.pointUpdate(pnt, writeValue, true)
 			}
 		} else {
 			inst.edge28DebugMsg(fmt.Sprintf("processWrite() WRITE DO %s as type:%s  value:%v\n", pnt.IoNumber, pnt.IoType, value))
@@ -220,7 +220,7 @@ func (inst *Instance) processWrite(pnt *model.Point, value float64, rest *edgere
 				inst.pointUpdateErr(pnt, err)
 				return 0, err
 			} else {
-				_, err = inst.pointUpdate(pnt, writeValue, true, true, true)
+				_, err = inst.pointUpdate(pnt, writeValue, true)
 			}
 		}
 		if err != nil {
@@ -242,7 +242,7 @@ func (inst *Instance) processRead(pnt *model.Point, readValue float64, pollCount
 	inst.edge28DebugMsg("processRead: pnt")
 	inst.edge28DebugMsg(fmt.Sprintf("%+v\n", pnt))
 	if pollCount == 1 || boolean.IsTrue(pnt.ReadPollRequired) {
-		_, err = inst.pointUpdate(pnt, readValue, true, true, true)
+		_, err = inst.pointUpdate(pnt, readValue, true)
 		if err != nil {
 			inst.edge28DebugMsg(fmt.Sprintf("READ UPDATE POINT %s: %v\n", pnt.IoNumber, readValue))
 			err := inst.pointUpdateErr(pnt, err)
@@ -254,7 +254,7 @@ func (inst *Instance) processRead(pnt *model.Point, readValue float64, pollCount
 			inst.edge28DebugMsg(fmt.Sprintf("READ ON START %s: %v\n", pnt.IoNumber, readValue))
 		}
 	} else if covEvent {
-		_, err = inst.pointUpdate(pnt, readValue, true, true, true)
+		_, err = inst.pointUpdate(pnt, readValue, true)
 		if err != nil {
 			inst.edge28ErrorMsg(fmt.Sprintf("READ UPDATE POINT %s: %v\n", pnt.IoNumber, readValue))
 			err := inst.pointUpdateErr(pnt, err)

--- a/plugin/nube/protocals/edge28/polling.go
+++ b/plugin/nube/protocals/edge28/polling.go
@@ -225,7 +225,7 @@ func (inst *Instance) processWrite(pnt *model.Point, value float64, rest *edgere
 		}
 		if err != nil {
 			inst.edge28ErrorMsg(fmt.Sprintf("processWrite() failed to write IO %s:  value:%f error:%v\n", pnt.IoNumber, value, err))
-			_, err := inst.pointUpdateErr(pnt, err)
+			err := inst.pointUpdateErr(pnt, err)
 			return 0, err
 		} else {
 			// log.Infof("edge28-polling: wrote IO %s: %v\n", pnt.IoNumber, value)
@@ -245,7 +245,7 @@ func (inst *Instance) processRead(pnt *model.Point, readValue float64, pollCount
 		_, err = inst.pointUpdate(pnt, readValue, true, true, true)
 		if err != nil {
 			inst.edge28DebugMsg(fmt.Sprintf("READ UPDATE POINT %s: %v\n", pnt.IoNumber, readValue))
-			_, err := inst.pointUpdateErr(pnt, err)
+			err := inst.pointUpdateErr(pnt, err)
 			return readValue, err
 		}
 		if boolean.IsTrue(pnt.InSync) {
@@ -257,7 +257,7 @@ func (inst *Instance) processRead(pnt *model.Point, readValue float64, pollCount
 		_, err = inst.pointUpdate(pnt, readValue, true, true, true)
 		if err != nil {
 			inst.edge28ErrorMsg(fmt.Sprintf("READ UPDATE POINT %s: %v\n", pnt.IoNumber, readValue))
-			_, err := inst.pointUpdateErr(pnt, err)
+			err := inst.pointUpdateErr(pnt, err)
 			return readValue, err
 		} else {
 			inst.edge28ErrorMsg(fmt.Sprintf("READ ON START %s: %v\n", pnt.IoNumber, readValue))

--- a/plugin/nube/protocals/lora/api.go
+++ b/plugin/nube/protocals/lora/api.go
@@ -68,7 +68,7 @@ func (inst *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 	})
 	mux.PATCH(plugin.PointsURL, func(ctx *gin.Context) {
 		body, _ := plugin.GetBODYPoint(ctx)
-		point, err := inst.updatePoint(body)
+		point, err := inst.db.UpdatePoint(body.UUID, body, true, false)
 		api.ResponseHandler(point, err, ctx)
 	})
 	mux.PATCH(plugin.PointsWriteURL, func(ctx *gin.Context) {

--- a/plugin/nube/protocals/lorawan/api.go
+++ b/plugin/nube/protocals/lorawan/api.go
@@ -42,7 +42,7 @@ func (inst *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 	})
 	mux.PATCH(plugin.PointsURL, func(ctx *gin.Context) {
 		body, _ := plugin.GetBODYPoint(ctx)
-		point, err := inst.db.UpdatePoint(body.UUID, body, true)
+		point, err := inst.db.UpdatePoint(body.UUID, body, true, false)
 		api.ResponseHandler(point, err, ctx)
 	})
 	mux.DELETE(plugin.NetworksURL, func(ctx *gin.Context) {

--- a/plugin/nube/protocals/lorawan/db.go
+++ b/plugin/nube/protocals/lorawan/db.go
@@ -3,12 +3,8 @@ package main
 import (
 	"errors"
 	"fmt"
-	"time"
-
 	"github.com/NubeIO/flow-framework/api"
 	"github.com/NubeIO/flow-framework/plugin/nube/protocals/lorawan/csmodel"
-	"github.com/NubeIO/flow-framework/utils/boolean"
-	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/times/utilstime"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	log "github.com/sirupsen/logrus"
 )
@@ -104,20 +100,13 @@ func (inst *Instance) createNewPoint(name string, deviceEUI string, deviceUUID s
 	return point, err
 }
 
-// pointUpdateValue update point present value
-func (inst *Instance) pointUpdateValue(uuid string, value float64) (*model.Point, error) {
-	var point model.Point
-	point.CommonFault.InFault = false
-	point.CommonFault.MessageLevel = model.MessageLevel.Info
-	point.CommonFault.MessageCode = model.CommonFaultCode.PointWriteOk
-	point.CommonFault.Message = fmt.Sprintf("last-updated: %s", utilstime.TimeStamp())
-	point.CommonFault.LastOk = time.Now().UTC()
-	point.InSync = boolean.NewTrue()
+// pointWrite update point present value
+func (inst *Instance) pointWrite(uuid string, value float64) error {
 	priority := map[string]*float64{"_16": &value}
-	_, _, _, _, err := inst.db.UpdatePointValue(uuid, &point, &priority, true)
+	pointWriter := model.PointWriter{Priority: &priority}
+	_, _, _, _, err := inst.db.PointWrite(uuid, &pointWriter, true)
 	if err != nil {
-		log.Error("lorawan: pointUpdateValue ", err)
-		return nil, err
+		log.Error("lorawan: pointWrite ", err)
 	}
-	return nil, nil
+	return err
 }

--- a/plugin/nube/protocals/lorawan/uplink.go
+++ b/plugin/nube/protocals/lorawan/uplink.go
@@ -83,6 +83,6 @@ func (inst *Instance) parseUplinkData(data *csmodel.BaseUplink, device *model.De
 			}
 		}
 		log.Debugf("lorawan: Update point %s value=%f", *point.AddressUUID, value)
-		inst.pointUpdateValue(point.UUID, value)
+		inst.pointWrite(point.UUID, value)
 	}
 }

--- a/plugin/nube/protocals/modbus/polling.go
+++ b/plugin/nube/protocals/modbus/polling.go
@@ -123,11 +123,13 @@ func (inst *Instance) ModbusPolling() error {
 			}
 			if !boolean.IsTrue(dev.Enable) {
 				inst.modbusErrorMsg("device is disabled.")
+				inst.db.SetErrorsForAllPointsOnDevice(dev.UUID, "device disabled", model.MessageLevel.Warning, model.CommonFaultCode.DeviceError, true)
 				netPollMan.PollingFinished(pp, pollStartTime, false, false, callback)
 				continue
 			}
 			if dev.AddressId <= 0 || dev.AddressId >= 255 {
 				inst.modbusErrorMsg("address is not valid.  modbus addresses must be between 1 and 254")
+				inst.db.SetErrorsForAllPointsOnDevice(dev.UUID, "address out of range", model.MessageLevel.Critical, model.CommonFaultCode.ConfigError, true)
 				netPollMan.PollingFinished(pp, pollStartTime, false, false, callback)
 				continue
 			}
@@ -207,7 +209,7 @@ func (inst *Instance) ModbusPolling() error {
 				if pnt.WriteValue != nil {
 					response, responseValue, err = inst.networkWrite(mbClient, pnt)
 					if err != nil {
-						_, err = inst.pointUpdateErr(pnt, err)
+						_, err = inst.pointUpdateErr(pnt, err.Error(), model.MessageLevel.Fail, model.CommonFaultCode.PointWriteError)
 						netPollMan.PollingFinished(pp, pollStartTime, false, false, callback)
 						continue
 					}
@@ -223,7 +225,7 @@ func (inst *Instance) ModbusPolling() error {
 			if boolean.IsTrue(pnt.ReadPollRequired) { // DO READ IF REQUIRED
 				response, responseValue, err = inst.networkRead(mbClient, pnt)
 				if err != nil {
-					_, err = inst.pointUpdateErr(pnt, err)
+					_, err = inst.pointUpdateErr(pnt, err.Error(), model.MessageLevel.Fail, model.CommonFaultCode.PointError)
 					netPollMan.PollingFinished(pp, pollStartTime, false, false, callback)
 					continue
 				}

--- a/plugin/nube/protocals/modbus/polling.go
+++ b/plugin/nube/protocals/modbus/polling.go
@@ -203,7 +203,7 @@ func (inst *Instance) ModbusPolling() error {
 			var responseValue float64
 			var response interface{}
 			writeSuccess := false
-			if isWriteable(pnt.WriteMode) && boolean.IsTrue(pnt.WritePollRequired) { // DO WRITE IF REQUIRED
+			if isWriteable(pnt.WriteMode, pnt.ObjectType) && boolean.IsTrue(pnt.WritePollRequired) { // DO WRITE IF REQUIRED
 				inst.modbusDebugMsg(fmt.Sprintf("modbus write point: %+v", pnt))
 				// pnt.PrintPointValues()
 				if pnt.WriteValue != nil {

--- a/plugin/nube/protocals/modbus/polling.go
+++ b/plugin/nube/protocals/modbus/polling.go
@@ -250,7 +250,7 @@ func (inst *Instance) ModbusPolling() error {
 					// fmt.Println("ModbusPolling: writeOnceWriteValueToPresentVal responseValue: ", responseValue)
 					readSuccess = true
 				}
-				_, err = inst.pointUpdate(pnt, responseValue, writeSuccess, readSuccess, true)
+				_, err = inst.pointUpdate(pnt, responseValue, readSuccess)
 			}
 
 			/*

--- a/plugin/nube/protocals/modbus/polling.go
+++ b/plugin/nube/protocals/modbus/polling.go
@@ -123,13 +123,13 @@ func (inst *Instance) ModbusPolling() error {
 			}
 			if !boolean.IsTrue(dev.Enable) {
 				inst.modbusErrorMsg("device is disabled.")
-				inst.db.SetErrorsForAllPointsOnDevice(dev.UUID, "device disabled", model.MessageLevel.Warning, model.CommonFaultCode.DeviceError, true)
+				inst.db.SetErrorsForAllPointsOnDevice(dev.UUID, "device disabled", model.MessageLevel.Warning, model.CommonFaultCode.DeviceError)
 				netPollMan.PollingFinished(pp, pollStartTime, false, false, callback)
 				continue
 			}
 			if dev.AddressId <= 0 || dev.AddressId >= 255 {
 				inst.modbusErrorMsg("address is not valid.  modbus addresses must be between 1 and 254")
-				inst.db.SetErrorsForAllPointsOnDevice(dev.UUID, "address out of range", model.MessageLevel.Critical, model.CommonFaultCode.ConfigError, true)
+				inst.db.SetErrorsForAllPointsOnDevice(dev.UUID, "address out of range", model.MessageLevel.Critical, model.CommonFaultCode.ConfigError)
 				netPollMan.PollingFinished(pp, pollStartTime, false, false, callback)
 				continue
 			}
@@ -209,7 +209,7 @@ func (inst *Instance) ModbusPolling() error {
 				if pnt.WriteValue != nil {
 					response, responseValue, err = inst.networkWrite(mbClient, pnt)
 					if err != nil {
-						_, err = inst.pointUpdateErr(pnt, err.Error(), model.MessageLevel.Fail, model.CommonFaultCode.PointWriteError)
+						err = inst.pointUpdateErr(pnt, err.Error(), model.MessageLevel.Fail, model.CommonFaultCode.PointWriteError)
 						netPollMan.PollingFinished(pp, pollStartTime, false, false, callback)
 						continue
 					}
@@ -225,7 +225,7 @@ func (inst *Instance) ModbusPolling() error {
 			if boolean.IsTrue(pnt.ReadPollRequired) { // DO READ IF REQUIRED
 				response, responseValue, err = inst.networkRead(mbClient, pnt)
 				if err != nil {
-					_, err = inst.pointUpdateErr(pnt, err.Error(), model.MessageLevel.Fail, model.CommonFaultCode.PointError)
+					err = inst.pointUpdateErr(pnt, err.Error(), model.MessageLevel.Fail, model.CommonFaultCode.PointError)
 					netPollMan.PollingFinished(pp, pollStartTime, false, false, callback)
 					continue
 				}

--- a/plugin/nube/protocals/modbus/pollqueue/poll_manager.go
+++ b/plugin/nube/protocals/modbus/pollqueue/poll_manager.go
@@ -256,21 +256,21 @@ func (pm *NetworkPollManager) PollQueueErrorChecking() {
 		}
 	}
 	for _, dev := range net.Devices {
+		deviceExistsInQueue := pm.PollQueue.CheckIfActiveDevicesListIncludes(dev.UUID)
+		if boolean.IsFalse(net.Enable) || boolean.IsFalse(dev.Enable) {
+			if deviceExistsInQueue {
+				pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Device UUID exist in Poll Queues for a disabled device./n")
+				pm.PollQueue.RemovePollingPointByDeviceUUID(dev.UUID)
+				continue
+			}
+		}
+		if boolean.IsTrue(net.Enable) && boolean.IsTrue(dev.Enable) && !deviceExistsInQueue {
+			pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Device UUID doesn't exist in active devices list./n")
+		}
 		if dev.Points != nil {
-			deviceExistsInQueue := pm.PollQueue.CheckIfActiveDevicesListIncludes(dev.UUID)
-			if boolean.IsFalse(dev.Enable) {
-				if deviceExistsInQueue {
-					pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Device UUID exist in Poll Queues for a disabled device./n")
-					pm.PollQueue.RemovePollingPointByDeviceUUID(dev.UUID)
-					continue
-				}
-			}
-			if boolean.IsTrue(dev.Enable) && !deviceExistsInQueue {
-				pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Device UUID doesn't exist in active devices list./n")
-			}
 			for _, pnt := range dev.Points {
 				if pnt != nil {
-					if boolean.IsFalse(pnt.Enable) {
+					if boolean.IsFalse(net.Enable) || boolean.IsFalse(dev.Enable) || boolean.IsFalse(pnt.Enable) {
 						pp, _ := pm.PollQueue.GetPollingPointByPointUUID(pnt.UUID)
 						if pp != nil {
 							pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Found disabled point in poll queue./n")
@@ -278,7 +278,7 @@ func (pm *NetworkPollManager) PollQueueErrorChecking() {
 						}
 						continue
 					}
-					if boolean.IsTrue(pnt.Enable) {
+					if boolean.IsTrue(net.Enable) && boolean.IsTrue(dev.Enable) && boolean.IsTrue(pnt.Enable) {
 						pp, err := pm.PollQueue.GetPollingPointByPointUUID(pnt.UUID)
 						if pp == nil || err != nil {
 							pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Polling point doesn't exist for point ", pnt.Name, "/n")

--- a/plugin/nube/protocals/modbus/pollqueue/poll_queue.go
+++ b/plugin/nube/protocals/modbus/pollqueue/poll_queue.go
@@ -76,16 +76,26 @@ func (nq *NetworkPriorityPollQueue) RemovePollingPointByPointUUID(pointUUID stri
 		nq.QueueUnloader.NextPollPoint = nil
 
 	}
-	pp, _ = nq.PriorityQueue.RemovePollingPointByPointUUID(pointUUID)
+	ppPQ, _ := nq.PriorityQueue.RemovePollingPointByPointUUID(pointUUID)
 	if pp != nil {
 		nq.pollQueueDebugMsg("RemovePollingPointByPointUUID(): Point is in the PriorityQueue")
+		return pp, true
 	}
-	pp, _ = nq.StandbyPollingPoints.RemovePollingPointByPointUUID(pointUUID)
+	ppSPQ, _ := nq.StandbyPollingPoints.RemovePollingPointByPointUUID(pointUUID)
 	if pp != nil {
 		nq.pollQueueDebugMsg("RemovePollingPointByPointUUID(): Point is in the StandbyPollingPoints Queue")
+		return pp, true
 	}
-	return pp, true
+	if pp != nil {
+		return pp, true
+	} else if ppPQ != nil {
+		return ppPQ, true
+	} else if ppSPQ != nil {
+		return ppSPQ, true
+	}
+	return pp, false
 }
+
 func (nq *NetworkPriorityPollQueue) RemovePollingPointByDeviceUUID(deviceUUID string) bool {
 	nq.pollQueueDebugMsg("RemovePollingPointByDeviceUUID(): ", deviceUUID)
 	nq.PriorityQueue.RemovePollingPointByDeviceUUID(deviceUUID)

--- a/plugin/nube/protocals/modbus/pollqueue/queue_loader.go
+++ b/plugin/nube/protocals/modbus/pollqueue/queue_loader.go
@@ -281,10 +281,10 @@ func (pm *NetworkPollManager) PollingPointCompleteNotification(pp *PollingPoint,
 		}
 	}
 
-	//pm.pollQueueDebugMsg(fmt.Sprintf("PollingPointCompleteNotification (ABOUT TO DB UPDATE): point  %+v", point))
+	// pm.pollQueueDebugMsg(fmt.Sprintf("PollingPointCompleteNotification (ABOUT TO DB UPDATE): point  %+v", point))
 	// point.PrintPointValues()
 	// TODO: WOULD BE GOOD IF THIS COULD BE MOVED TO app.go
-	point, err = pm.DBHandlerRef.UpdatePoint(point.UUID, point, true)
+	point, err = pm.DBHandlerRef.UpdatePoint(point.UUID, point, true, true)
 	// printPointDebugInfo(point)
 
 }
@@ -337,13 +337,13 @@ func (pm *NetworkPollManager) MakePollingPointRepollCallback(pp *PollingPoint, w
 		pm.PollQueue.AddPollingPoint(pp)
 
 		// TODO: WOULD BE GOOD IF THIS COULD BE MOVED TO app.go
-		//pm.pollQueueDebugMsg(fmt.Sprintf("pm.DBHandlerRef: %+v", pm.DBHandlerRef))
-		point, err = pm.DBHandlerRef.UpdatePoint(point.UUID, point, true)
+		// pm.pollQueueDebugMsg(fmt.Sprintf("pm.DBHandlerRef: %+v", pm.DBHandlerRef))
+		point, err = pm.DBHandlerRef.UpdatePoint(point.UUID, point, true, true)
 		if err != nil || point == nil {
 			pm.pollQueueErrorMsg(fmt.Sprintf("point DB UPDATE FAILED Err: %+v", err))
 			return
 		}
-		//pm.pollQueueDebugMsg(fmt.Sprintf("point after DB UPDATE: %+v", point))
+		// pm.pollQueueDebugMsg(fmt.Sprintf("point after DB UPDATE: %+v", point))
 		// printPointDebugInfo(point)
 	}
 	return f
@@ -456,6 +456,5 @@ func (pm *NetworkPollManager) SetPointPollRequiredFlagsBasedOnWriteMode(point *m
 	pm.pollQueueDebugMsg("MODBUS SetPointPollRequiredFlagsBasedOnWriteMode(): PRIORITY")
 	pm.pollQueueDebugMsg("%+v\n", point.Priority)
 
-	pm.DBHandlerRef.UpdatePoint(point.UUID, point, true)
-
+	pm.DBHandlerRef.UpdatePoint(point.UUID, point, true, true)
 }

--- a/plugin/nube/protocals/modbus/utils.go
+++ b/plugin/nube/protocals/modbus/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/NubeIO/flow-framework/plugin/nube/protocals/modbus/smod"
+	"github.com/NubeIO/flow-framework/utils/boolean"
 	"github.com/NubeIO/flow-framework/utils/float"
 	"github.com/NubeIO/flow-framework/utils/integer"
 	"github.com/NubeIO/flow-framework/utils/nstring"
@@ -33,20 +34,6 @@ const (
 	writeUint64
 	writeFloat64
 )
-
-func isWrite(t string) bool {
-	switch model.ObjectType(t) {
-	case model.ObjTypeWriteCoil, model.ObjTypeWriteCoils:
-		return true
-	case model.ObjTypeWriteHolding, model.ObjTypeWriteHoldings:
-		return true
-	case model.ObjTypeWriteInt16, model.ObjTypeWriteUint16:
-		return true
-	case model.ObjTypeWriteFloat32:
-		return true
-	}
-	return false
-}
 
 var err error
 
@@ -329,7 +316,25 @@ func SetPriorityArrayModeBasedOnWriteMode(pnt *model.Point) bool {
 	return false
 }
 
-func isWriteable(writeMode model.WriteMode) bool {
+func resetWriteableProperties(point *model.Point) *model.Point {
+	point.WriteValueOriginal = nil
+	point.WriteValue = nil
+	point.WritePriority = nil
+	point.CurrentPriority = nil
+	point.EnableWriteable = boolean.NewFalse()
+	point.WritePollRequired = boolean.NewFalse()
+	return point
+}
+
+func isWriteable(writeMode model.WriteMode, objectType string) bool {
+	if isWriteableObjectType(objectType) && isWriteableWriteMode(writeMode) {
+		return true
+	} else {
+		return false
+	}
+}
+
+func isWriteableWriteMode(writeMode model.WriteMode) bool {
 	switch writeMode {
 	case model.ReadOnce, model.ReadOnly:
 		return false
@@ -338,6 +343,20 @@ func isWriteable(writeMode model.WriteMode) bool {
 	default:
 		return false
 	}
+}
+
+func isWriteableObjectType(objectType string) bool {
+	switch objectType {
+	case string(model.ObjTypeWriteCoil), string(model.ObjTypeWriteCoils):
+		return true
+	case string(model.ObjTypeWriteHolding), string(model.ObjTypeWriteHoldings):
+		return true
+	case string(model.ObjTypeWriteInt16), string(model.ObjTypeWriteUint16):
+		return true
+	case string(model.ObjTypeWriteFloat32):
+		return true
+	}
+	return false
 }
 
 func checkForBooleanType(ObjectType, DataType string) (isTypeBool bool) {

--- a/plugin/nube/protocals/rubixio/api.go
+++ b/plugin/nube/protocals/rubixio/api.go
@@ -53,7 +53,7 @@ func (inst *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 	})
 	mux.PATCH(plugin.PointsURL, func(ctx *gin.Context) {
 		body, _ := plugin.GetBODYPoint(ctx)
-		point, err := inst.updatePoint(body)
+		point, err := inst.db.UpdatePoint(body.UUID, body, true, false)
 		api.ResponseHandler(point, err, ctx)
 	})
 	mux.PATCH(plugin.PointsWriteURL, func(ctx *gin.Context) {

--- a/plugin/nube/protocals/rubixio/app.go
+++ b/plugin/nube/protocals/rubixio/app.go
@@ -88,14 +88,6 @@ func (inst *Instance) updateDevice(body *model.Device) (device *model.Device, er
 	return device, nil
 }
 
-func (inst *Instance) updatePoint(body *model.Point) (point *model.Point, err error) {
-	point, err = inst.db.UpdatePoint(body.UUID, body, true)
-	if err != nil {
-		return nil, err
-	}
-	return point, nil
-}
-
 func (inst *Instance) deleteNetwork(body *model.Network) (ok bool, err error) {
 	ok, err = inst.db.DeleteNetwork(body.UUID)
 	if err != nil {
@@ -106,15 +98,8 @@ func (inst *Instance) deleteNetwork(body *model.Network) (ok bool, err error) {
 
 // writePoint update point. Called via API call.
 func (inst *Instance) writePoint(pntUUID string, body *model.PointWriter) (point *model.Point, err error) {
-	// TODO: check for PointWriteByName calls that might not flow through the plugin.
-	if body == nil {
-		return
-	}
-	point, _, _, _, err = inst.db.WritePoint(pntUUID, body, true)
-	if err != nil || point == nil {
-		return nil, err
-	}
-	return point, nil
+	point, _, _, _, err = inst.db.PointWrite(pntUUID, body, false)
+	return point, err
 }
 
 func (inst *Instance) deleteDevice(body *model.Device) (ok bool, err error) {

--- a/plugin/nube/protocals/rubixio/app.go
+++ b/plugin/nube/protocals/rubixio/app.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/NubeIO/flow-framework/api"
-	"github.com/NubeIO/flow-framework/utils/boolean"
 	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/nils"
 	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/times/utilstime"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
@@ -12,7 +11,6 @@ import (
 	"time"
 )
 
-// addNetwork add network
 func (inst *Instance) addNetwork(body *model.Network) (network *model.Network, err error) {
 	nets, err := inst.db.GetNetworksByPluginName(body.PluginPath, api.Args{})
 	if err != nil {
@@ -33,7 +31,6 @@ func (inst *Instance) addNetwork(body *model.Network) (network *model.Network, e
 	return body, nil
 }
 
-// addDevice add device
 func (inst *Instance) addDevice(body *model.Device) (device *model.Device, err error) {
 	network, err := inst.db.GetNetwork(body.NetworkUUID, api.Args{WithDevices: true})
 	if err != nil {
@@ -52,7 +49,6 @@ func (inst *Instance) addDevice(body *model.Device) (device *model.Device, err e
 	return device, nil
 }
 
-// addPoint add point
 func (inst *Instance) addPoint(body *model.Point) (point *model.Point, err error) {
 	if body.IoNumber == "" {
 		body.IoNumber = "UI1"
@@ -76,7 +72,6 @@ func (inst *Instance) addPoint(body *model.Point) (point *model.Point, err error
 	return point, nil
 }
 
-// updateNetwork update network
 func (inst *Instance) updateNetwork(body *model.Network) (network *model.Network, err error) {
 	network, err = inst.db.UpdateNetwork(body.UUID, body, true)
 	if err != nil {
@@ -85,7 +80,6 @@ func (inst *Instance) updateNetwork(body *model.Network) (network *model.Network
 	return network, nil
 }
 
-// updateDevice update device
 func (inst *Instance) updateDevice(body *model.Device) (device *model.Device, err error) {
 	device, err = inst.db.UpdateDevice(body.UUID, body, true)
 	if err != nil {
@@ -94,7 +88,6 @@ func (inst *Instance) updateDevice(body *model.Device) (device *model.Device, er
 	return device, nil
 }
 
-// updatePoint update point
 func (inst *Instance) updatePoint(body *model.Point) (point *model.Point, err error) {
 	point, err = inst.db.UpdatePoint(body.UUID, body, true)
 	if err != nil {
@@ -103,7 +96,6 @@ func (inst *Instance) updatePoint(body *model.Point) (point *model.Point, err er
 	return point, nil
 }
 
-// deleteNetwork delete network
 func (inst *Instance) deleteNetwork(body *model.Network) (ok bool, err error) {
 	ok, err = inst.db.DeleteNetwork(body.UUID)
 	if err != nil {
@@ -125,7 +117,6 @@ func (inst *Instance) writePoint(pntUUID string, body *model.PointWriter) (point
 	return point, nil
 }
 
-// deleteNetwork delete device
 func (inst *Instance) deleteDevice(body *model.Device) (ok bool, err error) {
 	ok, err = inst.db.DeleteDevice(body.UUID)
 	if err != nil {
@@ -134,7 +125,6 @@ func (inst *Instance) deleteDevice(body *model.Device) (ok bool, err error) {
 	return ok, nil
 }
 
-// deletePoint delete point
 func (inst *Instance) deletePoint(body *model.Point) (ok bool, err error) {
 	ok, err = inst.db.DeletePoint(body.UUID)
 	if err != nil {
@@ -143,41 +133,30 @@ func (inst *Instance) deletePoint(body *model.Point) (ok bool, err error) {
 	return ok, nil
 }
 
-// pointUpdate update point present value
-func (inst *Instance) pointUpdate(uuid string) (*model.Point, error) {
+func (inst *Instance) pointWrite(uuid string, value float64) error {
+	priority := map[string]*float64{"_16": &value}
+	pointWriter := model.PointWriter{Priority: &priority}
+	_, _, _, _, err := inst.db.PointWrite(uuid, &pointWriter, true)
+	if err != nil {
+		log.Error("edge28-app: pointWrite()", err)
+	}
+	return err
+}
+
+func (inst *Instance) pointUpdateSuccess(uuid string) error {
 	var point model.Point
 	point.CommonFault.InFault = false
 	point.CommonFault.MessageLevel = model.MessageLevel.Info
 	point.CommonFault.MessageCode = model.CommonFaultCode.Ok
 	point.CommonFault.Message = fmt.Sprintf("last-update: %s", utilstime.TimeStamp())
 	point.CommonFault.LastOk = time.Now().UTC()
-	_, err := inst.db.UpdatePoint(uuid, &point, true)
+	err := inst.db.UpdatePointErrors(uuid, &point)
 	if err != nil {
 		log.Error("edge28-app: UpdatePoint()", err)
-		return nil, err
 	}
-	return nil, nil
+	return err
 }
 
-// pointUpdate update point present value
-func (inst *Instance) pointUpdateValue(uuid string, value float64) (*model.Point, error) {
-	var point model.Point
-	point.CommonFault.InFault = false
-	point.CommonFault.MessageLevel = model.MessageLevel.Info
-	point.CommonFault.MessageCode = model.CommonFaultCode.Ok
-	point.CommonFault.Message = fmt.Sprintf("last-update: %s", utilstime.TimeStamp())
-	point.CommonFault.LastOk = time.Now().UTC()
-	priority := map[string]*float64{"_16": &value}
-	point.InSync = boolean.NewTrue()
-	_, _, _, _, err := inst.db.UpdatePointValue(uuid, &point, &priority, true)
-	if err != nil {
-		log.Error("edge28-app: pointUpdateValue()", err)
-		return nil, err
-	}
-	return nil, nil
-}
-
-// pointUpdate update point present value
 func (inst *Instance) pointUpdateErr(uuid string, err error) error {
 	var point model.Point
 	point.CommonFault.InFault = true
@@ -188,9 +167,8 @@ func (inst *Instance) pointUpdateErr(uuid string, err error) error {
 	err = inst.db.UpdatePointErrors(uuid, &point)
 	if err != nil {
 		log.Error("edge28-app: pointUpdateErr()", err)
-		return err
 	}
-	return nil
+	return err
 }
 
 func selectObjectType(selectedPlugin string) (objectType string, isOutput, isTypeBool bool) {
@@ -208,7 +186,6 @@ func selectObjectType(selectedPlugin string) (objectType string, isOutput, isTyp
 		objectType = PointsList.UI1.ObjectType
 	}
 	return
-
 }
 
 type Point struct {

--- a/plugin/nube/protocals/rubixio/app.go
+++ b/plugin/nube/protocals/rubixio/app.go
@@ -178,19 +178,19 @@ func (inst *Instance) pointUpdateValue(uuid string, value float64) (*model.Point
 }
 
 // pointUpdate update point present value
-func (inst *Instance) pointUpdateErr(uuid string, err error) (*model.Point, error) {
+func (inst *Instance) pointUpdateErr(uuid string, err error) error {
 	var point model.Point
 	point.CommonFault.InFault = true
 	point.CommonFault.MessageLevel = model.MessageLevel.Fail
 	point.CommonFault.MessageCode = model.CommonFaultCode.PointError
 	point.CommonFault.Message = err.Error()
 	point.CommonFault.LastFail = time.Now().UTC()
-	_, err = inst.db.UpdatePoint(uuid, &point, true)
+	err = inst.db.UpdatePointErrors(uuid, &point)
 	if err != nil {
 		log.Error("edge28-app: pointUpdateErr()", err)
-		return nil, err
+		return err
 	}
-	return nil, nil
+	return nil
 }
 
 func selectObjectType(selectedPlugin string) (objectType string, isOutput, isTypeBool bool) {

--- a/plugin/nube/protocals/rubixio/polling.go
+++ b/plugin/nube/protocals/rubixio/polling.go
@@ -47,12 +47,11 @@ func (inst *Instance) updateInputs(pnt *model.Point, inputs *rubixio.Inputs) {
 		case string(model.IOTypeRAW):
 			pointValue = raw
 		}
-		_, err = inst.pointUpdateValue(pnt.UUID, pointValue)
+		err = inst.pointWrite(pnt.UUID, pointValue)
 		if err != nil {
 			log.Errorln("rubixio.polling.syncInputs() failed to update point value")
 		}
 	}
-
 }
 
 func (inst *Instance) syncInputs(dev *model.Device, inputs *rubixio.Inputs) {
@@ -156,7 +155,6 @@ func (inst *Instance) writeOutput(dev *model.Device) {
 		log.Errorln("rubixio.polling.writeOutput() failed to do rest-api call err:", err)
 		return
 	}
-
 }
 
 func (inst *Instance) polling(p polling) error {

--- a/router/router.go
+++ b/router/router.go
@@ -278,13 +278,13 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 		{
 			pointRoutes.GET("", pointHandler.GetPoints)
 			pointRoutes.POST("/bulk", pointHandler.GetPointsBulk)
-			pointRoutes.POST("", pointHandler.CreatePoint)
 			pointRoutes.GET("/:uuid", pointHandler.GetPoint)
+			pointRoutes.GET("/name", pointHandler.GetPointByName)
+			pointRoutes.GET("/one/args", pointHandler.GetOnePointByArgs)
+			pointRoutes.POST("", pointHandler.CreatePoint)
 			pointRoutes.PATCH("/:uuid", pointHandler.UpdatePoint)
 			pointRoutes.PATCH("/write/:uuid", pointHandler.PointWrite)
-			pointRoutes.GET("/one/args", pointHandler.GetOnePointByArgs)
 			pointRoutes.DELETE("/:uuid", pointHandler.DeletePoint)
-			pointRoutes.GET("/name", pointHandler.GetPointByName)
 			pointRoutes.PATCH("/name", pointHandler.PointWriteByName)
 		}
 

--- a/src/dbhandler/devices.go
+++ b/src/dbhandler/devices.go
@@ -61,3 +61,19 @@ func (h *Handler) DeleteDevice(uuid string) (bool, error) {
 	}
 	return true, nil
 }
+
+func (h *Handler) SetErrorsForAllPointsOnDevice(networkUUID string, message string, messageLevel string, messageCode string, fromPlugin bool) error {
+	err := getDb().SetErrorsForAllPointsOnDevice(networkUUID, message, messageLevel, messageCode, fromPlugin)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) ClearErrorsForAllPointsOnDevice(networkUUID string, fromPlugin bool) error {
+	err := getDb().ClearErrorsForAllPointsOnDevice(networkUUID, fromPlugin)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/dbhandler/devices.go
+++ b/src/dbhandler/devices.go
@@ -46,6 +46,15 @@ func (h *Handler) CreateDevice(body *model.Device) (*model.Device, error) {
 	return q, nil
 }
 
+// UpdateDeviceErrors will only update the error properties of the device, all other properties will not be updated.
+func (h *Handler) UpdateDeviceErrors(uuid string, body *model.Device) error {
+	err := getDb().UpdateDeviceErrors(uuid, body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (h *Handler) UpdateDevice(uuid string, body *model.Device, fromPlugin bool) (*model.Device, error) {
 	q, err := getDb().UpdateDevice(uuid, body, fromPlugin)
 	if err != nil {
@@ -62,16 +71,16 @@ func (h *Handler) DeleteDevice(uuid string) (bool, error) {
 	return true, nil
 }
 
-func (h *Handler) SetErrorsForAllPointsOnDevice(networkUUID string, message string, messageLevel string, messageCode string, fromPlugin bool) error {
-	err := getDb().SetErrorsForAllPointsOnDevice(networkUUID, message, messageLevel, messageCode, fromPlugin)
+func (h *Handler) SetErrorsForAllPointsOnDevice(networkUUID string, message string, messageLevel string, messageCode string) error {
+	err := getDb().SetErrorsForAllPointsOnDevice(networkUUID, message, messageLevel, messageCode)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (h *Handler) ClearErrorsForAllPointsOnDevice(networkUUID string, fromPlugin bool) error {
-	err := getDb().ClearErrorsForAllPointsOnDevice(networkUUID, fromPlugin)
+func (h *Handler) ClearErrorsForAllPointsOnDevice(networkUUID string) error {
+	err := getDb().ClearErrorsForAllPointsOnDevice(networkUUID)
 	if err != nil {
 		return err
 	}

--- a/src/dbhandler/networks.go
+++ b/src/dbhandler/networks.go
@@ -108,3 +108,19 @@ func (h *Handler) DeleteNetwork(uuid string) (bool, error) {
 	}
 	return true, nil
 }
+
+func (h *Handler) SetErrorsForAllDevicesOnNetwork(networkUUID string, message string, messageLevel string, messageCode string, doPoints bool, fromPlugin bool) error {
+	err := getDb().SetErrorsForAllDevicesOnNetwork(networkUUID, message, messageLevel, messageCode, doPoints, fromPlugin)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) ClearErrorsForAllDevicesOnNetwork(networkUUID string, doPoints bool, fromPlugin bool) error {
+	err := getDb().ClearErrorsForAllDevicesOnNetwork(networkUUID, doPoints, fromPlugin)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/dbhandler/networks.go
+++ b/src/dbhandler/networks.go
@@ -13,6 +13,15 @@ func (h *Handler) CreateNetwork(body *model.Network, fromPlugin bool) (*model.Ne
 	return q, nil
 }
 
+// UpdateNetworkErrors will only update the error properties of the network, all other properties will not be updated.
+func (h *Handler) UpdateNetworkErrors(uuid string, body *model.Network) error {
+	err := getDb().UpdateNetworkErrors(uuid, body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (h *Handler) UpdateNetwork(uuid string, body *model.Network, fromPlugin bool) (*model.Network, error) {
 	q, err := getDb().UpdateNetwork(uuid, body, fromPlugin)
 	if err != nil {
@@ -109,16 +118,16 @@ func (h *Handler) DeleteNetwork(uuid string) (bool, error) {
 	return true, nil
 }
 
-func (h *Handler) SetErrorsForAllDevicesOnNetwork(networkUUID string, message string, messageLevel string, messageCode string, doPoints bool, fromPlugin bool) error {
-	err := getDb().SetErrorsForAllDevicesOnNetwork(networkUUID, message, messageLevel, messageCode, doPoints, fromPlugin)
+func (h *Handler) SetErrorsForAllDevicesOnNetwork(networkUUID string, message string, messageLevel string, messageCode string, doPoints bool) error {
+	err := getDb().SetErrorsForAllDevicesOnNetwork(networkUUID, message, messageLevel, messageCode, doPoints)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (h *Handler) ClearErrorsForAllDevicesOnNetwork(networkUUID string, doPoints bool, fromPlugin bool) error {
-	err := getDb().ClearErrorsForAllDevicesOnNetwork(networkUUID, doPoints, fromPlugin)
+func (h *Handler) ClearErrorsForAllDevicesOnNetwork(networkUUID string, doPoints bool) error {
+	err := getDb().ClearErrorsForAllDevicesOnNetwork(networkUUID, doPoints)
 	if err != nil {
 		return err
 	}

--- a/src/dbhandler/points.go
+++ b/src/dbhandler/points.go
@@ -36,14 +36,11 @@ func (h *Handler) CreatePoint(body *model.Point, fromPlugin, updatePoint bool) (
 }
 
 func (h *Handler) UpdatePoint(uuid string, body *model.Point, fromPlugin bool) (*model.Point, error) {
-	q, err := getDb().UpdatePoint(uuid, body, fromPlugin)
-	if err != nil {
-		return nil, err
-	}
-	return q, nil
+	return getDb().UpdatePoint(uuid, body, fromPlugin)
 }
 
-func (h *Handler) WritePoint(uuid string, body *model.PointWriter, fromPlugin bool) (returnPoint *model.Point, isPresentValueChange, isWriteValueChange, isPriorityChanged bool, err error) {
+func (h *Handler) WritePoint(uuid string, body *model.PointWriter, fromPlugin bool) (
+	returnPoint *model.Point, isPresentValueChange, isWriteValueChange, isPriorityChanged bool, err error) {
 	q, isPresentValueChange, isWriteValueChange, isPriorityChanged, err := getDb().PointWrite(uuid, body, fromPlugin)
 	if err != nil {
 		return nil, false, false, false, err
@@ -51,28 +48,14 @@ func (h *Handler) WritePoint(uuid string, body *model.PointWriter, fromPlugin bo
 	return q, isPresentValueChange, isWriteValueChange, isPriorityChanged, nil
 }
 
-func (h *Handler) UpdatePointValue(uuid string, body *model.Point, priority *map[string]*float64, fromPlugin bool) (returnPoint *model.Point, isPresentValueChange, isWriteValueChange, isPriorityChanged bool, err error) {
-	var pointModel *model.Point
-	query := getDb().DB.Where("uuid = ?", uuid).Preload("Priority").First(&pointModel)
-	if query.Error != nil {
-		return nil, false, false, false, query.Error
-	}
-	_ = getDb().DB.Model(&pointModel).Updates(&body)
-	p, isPresentValueChange, isWriteValueChange, isPriorityChanged, err := getDb().UpdatePointValue(pointModel, priority, fromPlugin)
-	if err != nil {
-		return nil, false, false, false, err
-	}
-
-	return p, isPresentValueChange, isWriteValueChange, isPriorityChanged, nil
+func (h *Handler) PointWrite(uuid string, pointWriter *model.PointWriter, fromPlugin bool) (
+	returnPoint *model.Point, isPresentValueChange, isWriteValueChange, isPriorityChanged bool, err error) {
+	return getDb().PointWrite(uuid, pointWriter, fromPlugin)
 }
 
 // UpdatePointErrors will only update the error properties of the point, all other properties will not be updated.
 func (h *Handler) UpdatePointErrors(uuid string, body *model.Point) error {
-	err := getDb().UpdatePointErrors(uuid, body)
-	if err != nil {
-		return err
-	}
-	return nil
+	return getDb().UpdatePointErrors(uuid, body)
 }
 
 func (h *Handler) GetOnePointByArgs(args api.Args) (*model.Point, error) {

--- a/src/dbhandler/points.go
+++ b/src/dbhandler/points.go
@@ -66,6 +66,15 @@ func (h *Handler) UpdatePointValue(uuid string, body *model.Point, priority *map
 	return p, isPresentValueChange, isWriteValueChange, isPriorityChanged, nil
 }
 
+// UpdatePointErrors will only update the error properties of the point, all other properties will not be updated.
+func (h *Handler) UpdatePointErrors(uuid string, body *model.Point) error {
+	err := getDb().UpdatePointErrors(uuid, body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (h *Handler) GetOnePointByArgs(args api.Args) (*model.Point, error) {
 	return getDb().GetOnePointByArgs(args)
 }

--- a/src/dbhandler/points.go
+++ b/src/dbhandler/points.go
@@ -21,13 +21,14 @@ func (h *Handler) GetPoint(uuid string, args api.Args) (*model.Point, error) {
 	return q, nil
 }
 
-func (h *Handler) CreatePoint(body *model.Point, fromPlugin, updatePoint bool) (*model.Point, error) {
+func (h *Handler) CreatePoint(body *model.Point, fromPlugin, updatePoint bool) (
+	*model.Point, error) {
 	pnt, err := getDb().CreatePoint(body, fromPlugin)
 	if err != nil {
 		return nil, err
 	}
 	if updatePoint {
-		pnt, err = getDb().UpdatePoint(pnt.UUID, pnt, fromPlugin) // MARC: UpdatePoint is called here so that the PresentValue and Priority are updated to use the fallback value.  Otherwise they are left as Null and the Edge28 Outputs are left floating.
+		pnt, err = getDb().UpdatePoint(pnt.UUID, pnt, fromPlugin, false) // MARC: UpdatePoint is called here so that the PresentValue and Priority are updated to use the fallback value.  Otherwise they are left as Null and the Edge28 Outputs are left floating.
 		if err != nil {
 			return nil, err
 		}
@@ -35,22 +36,14 @@ func (h *Handler) CreatePoint(body *model.Point, fromPlugin, updatePoint bool) (
 	return pnt, nil
 }
 
-func (h *Handler) UpdatePoint(uuid string, body *model.Point, fromPlugin bool) (*model.Point, error) {
-	return getDb().UpdatePoint(uuid, body, fromPlugin)
+func (h *Handler) UpdatePoint(uuid string, body *model.Point, fromPlugin bool, afterRealDeviceUpdate bool) (
+	*model.Point, error) {
+	return getDb().UpdatePoint(uuid, body, fromPlugin, afterRealDeviceUpdate)
 }
 
-func (h *Handler) WritePoint(uuid string, body *model.PointWriter, fromPlugin bool) (
+func (h *Handler) PointWrite(uuid string, pointWriter *model.PointWriter, afterRealDeviceUpdate bool) (
 	returnPoint *model.Point, isPresentValueChange, isWriteValueChange, isPriorityChanged bool, err error) {
-	q, isPresentValueChange, isWriteValueChange, isPriorityChanged, err := getDb().PointWrite(uuid, body, fromPlugin)
-	if err != nil {
-		return nil, false, false, false, err
-	}
-	return q, isPresentValueChange, isWriteValueChange, isPriorityChanged, nil
-}
-
-func (h *Handler) PointWrite(uuid string, pointWriter *model.PointWriter, fromPlugin bool) (
-	returnPoint *model.Point, isPresentValueChange, isWriteValueChange, isPriorityChanged bool, err error) {
-	return getDb().PointWrite(uuid, pointWriter, fromPlugin)
+	return getDb().PointWrite(uuid, pointWriter, true, afterRealDeviceUpdate)
 }
 
 // UpdatePointErrors will only update the error properties of the point, all other properties will not be updated.


### PR DESCRIPTION
These added functions are used to set the `CommonFault` properties of points of a device, or devices of a network.

@RaiBnod I also found that `CommonFault.InFault` property was not able to be cleared on networks, devices, and points.  I think the reason is because GORM doesn't write `false` unless it is specifically told to (see note below from docs).    I have added `.Select("*")` so that db calls will update all properties (including zero values).  I think this probably covers a bunch of cases where we might be sending zero values (`0` or `false` or `nil`).  But could you please check it over and confirm i'm not doing something dumb.  


Note on GORM Docs for `Update` and `Updates`:  https://gorm.io/docs/update.html#Updates-multiple-columns

> NOTE: When update with struct, GORM will only update non-zero fields, you might want to use map to update attributes or use Select to specify fields to update