### PR TITLE
Add central history producer enable flag

### DIFF
--- a/api/producer_history.go
+++ b/api/producer_history.go
@@ -3,7 +3,6 @@ package api
 import (
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
 	"github.com/gin-gonic/gin"
-	"time"
 )
 
 // The ProducerHistoryDatabase interface for encapsulating database access.
@@ -15,7 +14,6 @@ type ProducerHistoryDatabase interface {
 	GetLatestProducerHistoryByProducerUUID(pUuid string) (*model.ProducerHistory, error)
 	GetProducerHistoriesPoints(args Args) ([]*model.History, error)
 	GetProducerHistoriesPointsForSync(id string, timeStamp string) ([]*model.History, error)
-	CreateProducerHistory(history *model.ProducerHistory) (*model.ProducerHistory, error)
 	DeleteProducerHistoriesByProducerUUID(pUuid string, args Args) (bool, error)
 }
 type HistoriesAPI struct {
@@ -77,13 +75,6 @@ func (a *HistoriesAPI) GetProducerHistoriesPoints(ctx *gin.Context) {
 func (a *HistoriesAPI) GetProducerHistoriesPointsForSync(ctx *gin.Context) {
 	id, timeStamp := buildProducerHistoryPointsSyncArgs(ctx)
 	q, err := a.DB.GetProducerHistoriesPointsForSync(id, timeStamp)
-	ResponseHandler(q, err, ctx)
-}
-
-func (a *HistoriesAPI) CreateProducerHistory(ctx *gin.Context) {
-	body, _ := getBodyHistory(ctx)
-	body.Timestamp = time.Now().UTC()
-	q, err := a.DB.CreateProducerHistory(body)
 	ResponseHandler(q, err, ctx)
 }
 

--- a/app.go
+++ b/app.go
@@ -41,12 +41,12 @@ func intHandler(db *database.GormDatabase) {
 func initHistorySchedulers(db *database.GormDatabase, conf *config.Configuration) {
 	h := new(history.History)
 	h.DB = db
-	if *conf.ProducerHistory.Cleaner.Enable {
+	if *conf.ProducerHistory.Enable && *conf.ProducerHistory.Cleaner.Enable {
 		h.InitProducerHistoryCleaner(
 			conf.ProducerHistory.Cleaner.Frequency,
 			conf.ProducerHistory.Cleaner.DataPersistingHours)
 	}
-	if *conf.ProducerHistory.IntervalHistoryCreator.Enable {
+	if *conf.ProducerHistory.Enable && *conf.ProducerHistory.IntervalHistoryCreator.Enable {
 		h.InitIntervalHistoryCreator(conf.ProducerHistory.IntervalHistoryCreator.Frequency)
 	}
 }

--- a/config/config.eg.yml
+++ b/config/config.eg.yml
@@ -36,6 +36,7 @@ loglevel: "INFO" # options are: DEBUG, INFO, WARN, ERROR
 auth: true
 
 producerhistory:
+  enable: true
   cleaner:
     enable: true
     frequency: 600

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type Configuration struct {
 	Prod            bool  `default:"false"`
 	Auth            *bool `default:"true"`
 	ProducerHistory struct {
+		Enable  *bool `default:"true"`
 		Cleaner struct {
 			Enable              *bool `default:"true"`
 			Frequency           int   `default:"600"`

--- a/database/producer.go
+++ b/database/producer.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/NubeIO/flow-framework/api"
+	"github.com/NubeIO/flow-framework/config"
 	"github.com/NubeIO/flow-framework/interfaces"
 	"github.com/NubeIO/flow-framework/interfaces/connection"
 	"github.com/NubeIO/flow-framework/src/client"
@@ -207,7 +208,8 @@ func (d *GormDatabase) producerPointWrite(uuid string, priority *map[string]*flo
 	if err != nil {
 		return err
 	}
-	if createCOVHistory && boolean.IsTrue(producerModel.EnableHistory) && checkHistoryCovType(string(producerModel.HistoryType)) {
+	if boolean.IsTrue(config.Get().ProducerHistory.Enable) && createCOVHistory &&
+		boolean.IsTrue(producerModel.EnableHistory) && checkHistoryCovType(string(producerModel.HistoryType)) {
 		ph := new(model.ProducerHistory)
 		ph.ProducerUUID = uuid
 		ph.PresentValue = presentValue

--- a/router/router.go
+++ b/router/router.go
@@ -198,7 +198,6 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			historyProducerRoutes.GET("/:producer_uuid/one", historyHandler.GetLatestProducerHistoryByProducerUUID)
 			historyProducerRoutes.GET("/points", historyHandler.GetProducerHistoriesPoints)
 			historyProducerRoutes.GET("/points_for_sync", historyHandler.GetProducerHistoriesPointsForSync)
-			historyProducerRoutes.POST("", historyHandler.CreateProducerHistory)
 			historyProducerRoutes.DELETE("/:producer_uuid", historyHandler.DeleteProducerHistoriesByProducerUUID)
 		}
 


### PR DESCRIPTION
Resolves: #589
### Summary:
- Add central history producer enable flag
- Removed `histories/producers` POST endpoint.