### PR TITLE
Release/0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # CHANGELOG
 
+## [v0.6.7](https://github.com/NubeIO/flow-framework/tree/v0.6.7) (2022-08-18)
+
+- allow user to delete network if plugin is not installed
+- got bacnet-server plugin working with the new bacnet-server app
+- remove backup plugin
+- Merge pull request #606 from NubeIO/cleanup-of-mapping
+- add bacnet read priority
+- Merge pull request #608 from NubeIO/list-serial-ports
+- Merge pull request #610 from NubeIO/redo-json-schema
+- Merge pull request #611 from NubeIO/resync-bacnet-names
+- Merge pull request #612 from NubeIO/fix-bacnet-master-net
+- Merge pull request #613 from NubeIO/bump-schema
+- Fix: remove GlobalUUID unique constraint
+- Fix: remove GlobalUUID unique constraint
+- Fix: remove consumer's producer_uuid unique index
+
 ## [v0.6.6](https://github.com/NubeIO/flow-framework/tree/v0.6.6) (2022-08-09)
+
 - Issue/producer history current writer UUID #598
 - Improvements/misc #596
 - Add central history producer enable flag #594

--- a/plugin/nube/database/postgres/pgmodel/model.go
+++ b/plugin/nube/database/postgres/pgmodel/model.go
@@ -81,7 +81,7 @@ type Consumer struct {
 	CommonName
 	CommonDescription
 	CommonEnable
-	ProducerUUID       string    `json:"producer_uuid,omitempty" gorm:"uniqueIndex;not null"`
+	ProducerUUID       string    `json:"producer_uuid,omitempty"`
 	ProducerThingName  string    `json:"producer_thing_name,omitempty"`
 	ProducerThingUUID  string    `json:"producer_thing_uuid,omitempty"` // this is the remote point UUID
 	ProducerThingClass string    `json:"producer_thing_class,omitempty"`

--- a/plugin/nube/database/postgres/postgres.go
+++ b/plugin/nube/database/postgres/postgres.go
@@ -60,6 +60,9 @@ func autoMigrate(db *gorm.DB) error {
 	if (db.Migrator().HasConstraint(&pgmodel.FlowNetworkClone{}, "flow_network_clones_global_uuid_key")) {
 		_ = db.Migrator().DropConstraint(&pgmodel.FlowNetworkClone{}, "flow_network_clones_global_uuid_key")
 	}
+	if (db.Migrator().HasIndex(&pgmodel.Consumer{}, "idx_consumers_producer_uuid")) {
+		_ = db.Migrator().DropIndex(&pgmodel.Consumer{}, "idx_consumers_producer_uuid")
+	}
 	for _, s := range interfaces {
 		if err := db.AutoMigrate(s); err != nil {
 			return err


### PR DESCRIPTION
### Summary

- allow user to delete network if plugin is not installed
- got bacnet-server plugin working with the new bacnet-server app
- remove backup plugin
- Merge pull request #606 from NubeIO/cleanup-of-mapping
- add bacnet read priority
- Merge pull request #608 from NubeIO/list-serial-ports
- Merge pull request #610 from NubeIO/redo-json-schema
- Merge pull request #611 from NubeIO/resync-bacnet-names
- Merge pull request #612 from NubeIO/fix-bacnet-master-net
- Merge pull request #613 from NubeIO/bump-schema
- Fix: remove GlobalUUID unique constraint
- Fix: remove GlobalUUID unique constraint
- Fix: remove consumer's producer_uuid unique index