### PR TITLE
fix nil pointer issue

### DIFF
--- a/services/pollqueue/poll_queue.go
+++ b/services/pollqueue/poll_queue.go
@@ -256,8 +256,10 @@ func (q *PriorityPollQueue) Pop() interface{} {
 }
 func (q *PriorityPollQueue) GetPollingPointIndexByPointUUID(pointUUID string) int {
 	for index, pp := range q.PriorityQueue {
-		if pp.FFPointUUID == pointUUID {
-			return index
+		if pp != nil { // i got a nil pointer issue here and it crashed FF @Marc to look (aidan)
+			if pp.FFPointUUID == pointUUID {
+				return index
+			}
 		}
 	}
 	return -1


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7f2879ca9ba3]

goroutine 60 [running]:
github.com/NubeIO/flow-framework/services/pollqueue.(*PriorityPollQueue).GetPollingPointIndexByPointUUID(0x7f287964e7cc, {0xc000344ab0, 0x14})
        /home/aidan/code/go/nube/flow-framework/services/pollqueue/poll_queue.go:259 +0x43
github.com/NubeIO/flow-framework/services/pollqueue.(*PriorityPollQueue).AddPollingPoint(0xc000414ea0, 0xc0004a2b60)
        /home/aidan/code/go/nube/flow-framework/services/pollqueue/poll_queue.go:320 +0x2e
github.com/NubeIO/flow-framework/services/pollqueue.(*NetworkPollManager).PollingPointCompleteNotification(0xc000414ea0, 0xc0004a2b60, 0x0, 0x1, 0x3f9654ac7fa551b4, 0x0, 0x1, {0x7f2879dafd3d, 0xc})
        /home/aidan/code/go/nube/flow-framework/services/pollqueue/queue_loader.go:137 +0xd3a
github.com/NubeIO/flow-framework/services/pollqueue.(*NetworkPollManager).PollingFinished(0xc000dcc000, 0x0, {0x1, 0x2, 0x185af40}, 0x0, 0x0, {0x7f2879dafd3d, 0xc}, 0xc000a25b58)
        /home/aidan/code/go/nube/flow-framework/services/pollqueue/poll_manager.go:240 +0xea
plugin/unnamed-bcf7036620b943a25b7eaf005e6cee7e5940459e.(*Instance).BACnetMasterPolling.func1()
        /home/aidan/code/go/nube/flow-framework/plugin/nube/protocals/bacnetmaster/polling.go:265 +0x1554
github.com/NubeIO/flow-framework/src/poller.Poller.GoPoll({0xc00014c240}, {0x1281418, 0xc000179200}, 0xc000177ad0)
        /home/aidan/code/go/nube/flow-framework/src/poller/poller.go:81 +0x1d7
created by plugin/unnamed-bcf7036620b943a25b7eaf005e6cee7e5940459e.(*Instance).BACnetMasterPolling
        /home/aidan/code/go/nube/flow-framework/plugin/nube/protocals/bacnetmaster/polling.go:273 +0x15b
