### PR TITLE
Add postgres histories API endpoint

### DIFF
--- a/plugin/nube/database/postgres/README.md
+++ b/plugin/nube/database/postgres/README.md
@@ -8,3 +8,41 @@
 ### How to get default config
 
 - Save empty `YAML` file, and it will generate you the default config file
+
+# History api
+
+### Query params
+- filter
+    - Logical Operators `(make sure it is url encoded)`
+        - `&&`, `||` 
+    - Comparision Operators
+        - `=`, `>`, `<`, `<=`, `>=`, `!=` 
+    - Fields 
+        - `value`
+        - `timestamp`
+        - `rubix_network_uuid`
+        - `rubix_network_name`
+        - `rubix_device_uuid`
+        - `rubix_device_name`
+        - `rubix_point_uuid`
+        - `rubix_point_name`
+        - `global_uuid`
+        - `client_id`
+        - `client_name`
+        - `site_id`
+        - `site_name`
+        - `device_id`
+        - `device_name`
+        - `tag`     
+    - Filter examples:   
+        ```
+        1. rubix_network_name={network_name}&&rubix_device_name={device_name}&&rubix_point_name={point_name}&&site_id={site_id}
+        2. (site_name={site_name}&&timestamp>{timestamp})||rubix_point_uuid!={point_uuid}
+        3. (tag={tag}&&value>={value})||(tag={tag}&&value<={value})
+        4. rubix_point_uuid=<{oint_uuid}||rubix_point_uuid={point_uuid}
+        ```
+- limit
+- offset
+
+### Endpoint
+- GET `/api/plugins/api/postgres/histories?filter=<filter>&limit=<int>&offset=<int>`

--- a/plugin/nube/database/postgres/api.go
+++ b/plugin/nube/database/postgres/api.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"github.com/NubeIO/flow-framework/api"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	relativePathHistories = "/histories"
+	filterRegex           = "[^()!|<=>&']+|([&]+[&])+|([|]+[|])+|([!]+[=])+|([>]+[=])+|([<]+[=])+|[()<>=]"
+	operatorFormat        = "{opt}"
+	valueFormat           = "{val}"
+)
+
+var (
+	logicalOperators        = []string{"&&", "||"}
+	comparisonOperators     = []string{"=", ">", "<", "<=", ">=", "!="}
+	orderOperators          = []string{"(", ")"}
+	tagColumns              = []string{"tag"}
+	flowNetworkCloneColumns = []string{"global_uuid", "client_id", "client_name", "site_id", "site_name", "device_id",
+		"device_name"}
+	filterMap = map[string]string{
+		"timestamp":          "histories.timestamp",
+		"value":              "histories.value",
+		"rubix_network_uuid": "networks.uuid",
+		"rubix_network_name": "networks.name",
+		"rubix_device_uuid":  "devices.uuid",
+		"rubix_device_name":  "devices.name",
+		"rubix_point_uuid":   "points.uuid",
+		"rubix_point_name":   "points.name",
+		"tag":                "networks_tags.tag_tag,devices_tags.tag_tag,points_tags.tag_tag",
+		"global_uuid":        "flow_network_clones.global_uuid",
+		"client_id":          "flow_network_clones.client_id",
+		"client_name":        "flow_network_clones.client_name",
+		"site_id":            "flow_network_clones.site_id",
+		"site_name":          "flow_network_clones.site_name",
+		"device_id":          "flow_network_clones.device_id",
+		"device_name":        "flow_network_clones.device_name",
+	}
+)
+
+type Args struct {
+	Filter *string
+	Limit  *string
+	Offset *string
+}
+
+var ArgsType = struct {
+	Filter string
+	Limit  string
+	Offset string
+}{
+	Filter: "filter",
+	Limit:  "limit",
+	Offset: "offset",
+}
+
+func buildHistoryArgs(ctx *gin.Context) Args {
+	var args Args
+	var aType = ArgsType
+	if value, ok := ctx.GetQuery(aType.Filter); ok {
+		args.Filter = &value
+	}
+	if value, ok := ctx.GetQuery(aType.Limit); ok {
+		args.Limit = &value
+	}
+	if value, ok := ctx.GetQuery(aType.Offset); ok {
+		args.Offset = &value
+	}
+	return args
+}
+
+func (inst *Instance) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
+	inst.basePath = basePath
+	mux.GET(relativePathHistories, func(ctx *gin.Context) {
+		args := buildHistoryArgs(ctx)
+		q, err := inst.getHistories(args)
+		api.ResponseHandler(q, err, ctx)
+	})
+}

--- a/plugin/nube/database/postgres/app.go
+++ b/plugin/nube/database/postgres/app.go
@@ -104,3 +104,14 @@ func (inst *Instance) syncPostgres() (bool, error) {
 	}
 	return true, nil
 }
+
+func (inst *Instance) getHistories(args Args) ([]*pgmodel.HistoryData, error) {
+	if postgresSetting.postgresConnectionInstance.db == nil {
+		err := postgresSetting.New()
+		if err != nil {
+			log.Warn(err)
+			return nil, err
+		}
+	}
+	return postgresSetting.GetHistories(args)
+}

--- a/plugin/nube/database/postgres/pgmodel/model.go
+++ b/plugin/nube/database/postgres/pgmodel/model.go
@@ -148,3 +148,32 @@ type History struct {
 	Value     float64   `json:"value" gorm:"primary_key"`
 	Timestamp time.Time `json:"timestamp" gorm:"primary_key"`
 }
+
+type HistoryData struct {
+	Value            float64   `json:"value"`
+	Timestamp        time.Time `json:"timestamp"`
+	RubixNetworkUUID string    `json:"rubix_network_uuid"`
+	RubixNetworkName string    `json:"rubix_network_name"`
+	RubixDeviceUUID  string    `json:"rubix_device_uuid"`
+	RubixDeviceName  string    `json:"rubix_device_name"`
+	RubixPointUUID   string    `json:"rubix_point_uuid"`
+	RubixPointName   string    `json:"rubix_point_name"`
+	TagData
+	FlowNetworkCloneData
+}
+
+type TagData struct {
+	NetworkTag string `json:"network_tag,omitempty"`
+	DeviceTag  string `json:"device_tag,omitempty"`
+	PointTag   string `json:"point_tag,omitempty"`
+}
+
+type FlowNetworkCloneData struct {
+	GlobalUUID string `json:"global_uuid,omitempty"`
+	ClintId    string `json:"client_id,omitempty"`
+	ClintName  string `json:"client_name,omitempty"`
+	SiteId     string `json:"site_id,omitempty"`
+	SiteName   string `json:"site_name,omitempty"`
+	DeviceId   string `json:"device_id,omitempty"`
+	DeviceName string `json:"device_name,omitempty"`
+}

--- a/plugin/nube/database/postgres/utils.go
+++ b/plugin/nube/database/postgres/utils.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func buildSelectQuery(hasTag bool, hasFnc bool) string {
+	query := "histories.value, histories.timestamp, points.uuid AS rubix_point_uuid, points.name AS rubix_point_name," +
+		" devices.uuid AS rubix_device_uuid, devices.name AS rubix_device_name, networks.uuid AS rubix_network_uuid," +
+		" networks.name AS rubix_network_name"
+	if hasTag {
+		tagQuery := ", networks_tags.tag_tag AS network_tag, devices_tags.tag_tag AS device_tag, " +
+			"points_tags.tag_tag AS point_tag"
+		query += fmt.Sprintf("%s", tagQuery)
+	}
+	if hasFnc {
+		fncQuery := ", flow_network_clones.global_uuid, flow_network_clones.client_id, " +
+			"flow_network_clones.client_name, flow_network_clones.site_id, flow_network_clones.site_name, " +
+			"flow_network_clones.device_id, flow_network_clones.device_name"
+		query += fmt.Sprintf("%s", fncQuery)
+	}
+	return query
+}
+
+func buildFilterQuery(filter *string) (filterQuery string, hasTag bool, hasFnc bool, err error) {
+	if filter == nil {
+		return "", hasTag, hasFnc, nil
+	}
+	isColumn := true
+	re := regexp.MustCompile(filterRegex)
+	filters := re.FindAllString(*filter, -1)
+	for _, f := range filters {
+		if contains(f, orderOperators) {
+			filterQuery += f
+			continue
+		}
+		if contains(f, comparisonOperators) {
+			filterQuery = strings.Replace(filterQuery, operatorFormat, f, -1)
+			continue
+		}
+		if contains(f, logicalOperators) {
+			if f == "&&" {
+				filterQuery += " AND "
+			} else {
+				filterQuery += " OR "
+			}
+			continue
+		}
+		if isColumn {
+			column, err := getColumn(f)
+			if err != nil {
+				return "", hasTag, hasFnc, err
+			}
+			filterQuery += column
+			hasTag = hasTag || contains(f, tagColumns)
+			hasFnc = hasFnc || contains(f, flowNetworkCloneColumns)
+		} else {
+			value := fmt.Sprintf("'%s'", f)
+			filterQuery = strings.Replace(filterQuery, valueFormat, value, -1)
+		}
+		isColumn = !isColumn
+	}
+	return filterQuery, hasTag, hasFnc, err
+}
+
+func getColumn(key string) (string, error) {
+	columns := strings.Split(filterMap[key], ",")
+	if columns[0] == "" {
+		return "", errors.New("invalid column")
+	}
+	if len(columns) == 1 {
+		return fmt.Sprintf("%s%s%s", columns[0], operatorFormat, valueFormat), nil
+	}
+	column := "("
+	for i, f := range columns {
+		if i == len(columns)-1 {
+			column += fmt.Sprintf("%s%s%s%s", f, operatorFormat, valueFormat, ")")
+		} else {
+			column += fmt.Sprintf("%s%s%s %s ", f, operatorFormat, valueFormat, "OR")
+		}
+	}
+	return column, nil
+}
+
+func contains(v string, a []string) bool {
+	for _, i := range a {
+		if i == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Resolves: #175
### Summary:
- Add API endpoint (`/api/plugins/api/postgres/histories?filter=<filter>&limit=<int>&offset=<int>`) to query postgres history data
- Filter Examples :
```
        1. rubix_network_name={network_name}&&rubix_device_name={device_name}&&rubix_point_name={point_name}&&site_id={site_id}
        2. (site_name={site_name}&&timestamp>{timestamp})||rubix_point_uuid!={point_uuid}
        3. (tag={tag}&&value>={value})||(tag={tag}&&value<={value})
        4. rubix_point_uuid=<{oint_uuid}||rubix_point_uuid={point_uuid}
```