### PR TITLE
Add order_by, order and group_limit args in postgres api endpoint

### DIFF
--- a/plugin/nube/database/postgres/README.md
+++ b/plugin/nube/database/postgres/README.md
@@ -43,6 +43,9 @@
         ```
 - limit
 - offset
+- order_by
+- order [default: DESC]
+- group_limit
 
 ### Endpoint
-- GET `/api/plugins/api/postgres/histories?filter=<filter>&limit=<int>&offset=<int>`
+- GET `/api/plugins/api/postgres/histories?filter=<filter>&limit=<int>&offset=<int>&order_by=<order_by>&order=<order>&group_limit=<group_limit>`

--- a/plugin/nube/database/postgres/api.go
+++ b/plugin/nube/database/postgres/api.go
@@ -40,19 +40,28 @@ var (
 )
 
 type Args struct {
-	Filter *string
-	Limit  *string
-	Offset *string
+	Filter     *string
+	Limit      *string
+	Offset     *string
+	OrderBy    *string
+	Order      *string
+	GroupLimit *string
 }
 
 var ArgsType = struct {
-	Filter string
-	Limit  string
-	Offset string
+	Filter     string
+	Limit      string
+	Offset     string
+	OrderBy    string
+	Order      string
+	GroupLimit string
 }{
-	Filter: "filter",
-	Limit:  "limit",
-	Offset: "offset",
+	Filter:     "filter",
+	Limit:      "limit",
+	Offset:     "offset",
+	OrderBy:    "order_by",
+	Order:      "order",
+	GroupLimit: "group_limit",
 }
 
 func buildHistoryArgs(ctx *gin.Context) Args {
@@ -66,6 +75,15 @@ func buildHistoryArgs(ctx *gin.Context) Args {
 	}
 	if value, ok := ctx.GetQuery(aType.Offset); ok {
 		args.Offset = &value
+	}
+	if value, ok := ctx.GetQuery(aType.OrderBy); ok {
+		args.OrderBy = &value
+	}
+	if value, ok := ctx.GetQuery(aType.Order); ok {
+		args.Order = &value
+	}
+	if value, ok := ctx.GetQuery(aType.GroupLimit); ok {
+		args.GroupLimit = &value
 	}
 	return args
 }


### PR DESCRIPTION
Related to: #662

### Summary
- Added `order_by`, `order`_(default to DESC)_ and `group_limit` args.
- Examples:
  ```
   1. api/postgres/histories?order_by=rubix_point_uuid
   2. api/postgres/histories?order_by=rubix_point_uuid&order=asc
   3. api/postgres/histories?group_limit=3
   4. api/postgres/histories?order_by=rubix_point_name&order=asc&group_limit=1
  ```