### PR TITLE
Add meta tags on network, device and point

### DIFF
--- a/api/args.go
+++ b/api/args.go
@@ -64,6 +64,7 @@ type Args struct {
 	IsMetadata           bool
 	NetworkUUID          *string
 	DeviceUUID           *string
+	WithMetaTags         bool
 }
 
 var ArgsType = struct {
@@ -130,6 +131,7 @@ var ArgsType = struct {
 	IsMetadata           string
 	NetworkUUID          string
 	DeviceUUID           string
+	WithMetaTags         string
 }{
 	Sort:                 "sort",
 	Order:                "order",
@@ -194,6 +196,7 @@ var ArgsType = struct {
 	IsMetadata:           "is_metadata",
 	NetworkUUID:          "network_uuid",
 	DeviceUUID:           "device_uuid",
+	WithMetaTags:         "with_meta_tags",
 }
 
 var ArgsDefault = struct {
@@ -238,6 +241,7 @@ var ArgsDefault = struct {
 	IsMetadata        string
 	NetworkUUID       string
 	DeviceUUID        string
+	WithMetaTags      string
 }{
 	Sort:              "ID",
 	Order:             "DESC", // ASC or DESC
@@ -279,4 +283,5 @@ var ArgsDefault = struct {
 	IsMetadata:        "false",
 	NetworkUUID:       "",
 	DeviceUUID:        "",
+	WithMetaTags:      "false",
 }

--- a/api/args_builder.go
+++ b/api/args_builder.go
@@ -132,6 +132,7 @@ func buildNetworkArgs(ctx *gin.Context) Args {
 	args.WithDevices, _ = toBool(ctx.DefaultQuery(aType.WithDevices, aDefault.WithDevices))
 	args.WithPoints, _ = toBool(ctx.DefaultQuery(aType.WithPoints, aDefault.WithPoints))
 	args.WithTags, _ = toBool(ctx.DefaultQuery(aType.WithTags, aDefault.WithTags))
+	args.WithMetaTags, _ = toBool(ctx.DefaultQuery(aType.WithMetaTags, aDefault.WithMetaTags))
 	if value, ok := ctx.GetQuery(aType.FlowNetworkUUID); ok {
 		args.FlowNetworkUUID = value
 	}
@@ -145,6 +146,7 @@ func buildDeviceArgs(ctx *gin.Context) Args {
 	args.WithPriority, _ = toBool(ctx.DefaultQuery(aType.WithPriority, aDefault.WithPriority))
 	args.WithPoints, _ = toBool(ctx.DefaultQuery(aType.WithPoints, aDefault.WithPoints))
 	args.WithTags, _ = toBool(ctx.DefaultQuery(aType.WithTags, aDefault.WithTags))
+	args.WithMetaTags, _ = toBool(ctx.DefaultQuery(aType.WithMetaTags, aDefault.WithMetaTags))
 	if value, ok := ctx.GetQuery(aType.AddressUUID); ok {
 		args.AddressUUID = &value
 	}
@@ -157,6 +159,7 @@ func buildPointArgs(ctx *gin.Context) Args {
 	var aDefault = ArgsDefault
 	args.WithPriority, _ = toBool(ctx.DefaultQuery(aType.WithPriority, aDefault.WithPriority))
 	args.WithTags, _ = toBool(ctx.DefaultQuery(aType.WithTags, aDefault.WithTags))
+	args.WithMetaTags, _ = toBool(ctx.DefaultQuery(aType.WithMetaTags, aDefault.WithMetaTags))
 	if value, ok := ctx.GetQuery(aType.AddressUUID); ok {
 		args.AddressUUID = &value
 	}

--- a/api/device.go
+++ b/api/device.go
@@ -17,6 +17,8 @@ type DeviceDatabase interface {
 	CreateDevicePlugin(body *model.Device) (*model.Device, error)
 	UpdateDevicePlugin(uuid string, body *model.Device) (*model.Device, error)
 	DeleteDevicePlugin(uuid string) (bool, error)
+
+	CreateDeviceMetaTags(deviceUUID string, deviceMetaTags []*model.DeviceMetaTag) ([]*model.DeviceMetaTag, error)
 }
 type DeviceAPI struct {
 	DB DeviceDatabase
@@ -65,5 +67,16 @@ func (a *DeviceAPI) CreateDevice(ctx *gin.Context) {
 func (a *DeviceAPI) DeleteDevice(ctx *gin.Context) {
 	uuid := resolveID(ctx)
 	q, err := a.DB.DeleteDevicePlugin(uuid)
+	ResponseHandler(q, err, ctx)
+}
+
+func (a *DeviceAPI) CreateDeviceMetaTags(ctx *gin.Context) {
+	deviceUUID := resolveID(ctx)
+	body, _ := getBodyBulkDeviceMetaTag(ctx)
+	q, err := a.DB.CreateDeviceMetaTags(deviceUUID, body)
+	if err != nil {
+		ResponseHandler(q, err, ctx)
+		return
+	}
 	ResponseHandler(q, err, ctx)
 }

--- a/api/internal_utils.go
+++ b/api/internal_utils.go
@@ -174,6 +174,21 @@ func getBodyTokenBlock(ctx *gin.Context) (dto *interfaces.TokenBlock, err error)
 	return dto, err
 }
 
+func getBodyBulkNetworkMetaTags(ctx *gin.Context) (dto []*model.NetworkMetaTag, err error) {
+	err = ctx.ShouldBindJSON(&dto)
+	return dto, err
+}
+
+func getBodyBulkDeviceMetaTag(ctx *gin.Context) (dto []*model.DeviceMetaTag, err error) {
+	err = ctx.ShouldBindJSON(&dto)
+	return dto, err
+}
+
+func getBodyBulkPointMetaTag(ctx *gin.Context) (dto []*model.PointMetaTag, err error) {
+	err = ctx.ShouldBindJSON(&dto)
+	return dto, err
+}
+
 func getP2PBody(ctx *gin.Context) (dto *model.P2PBody, err error) {
 	err = ctx.ShouldBindJSON(&dto)
 	return dto, err

--- a/api/network.go
+++ b/api/network.go
@@ -21,6 +21,8 @@ type NetworkDatabase interface {
 	CreateNetworkPlugin(network *model.Network) (*model.Network, error)
 	UpdateNetworkPlugin(uuid string, body *model.Network) (*model.Network, error)
 	DeleteNetworkPlugin(uuid string) (bool, error)
+
+	CreateNetworkMetaTags(networkUUID string, networkMetaTags []*model.NetworkMetaTag) ([]*model.NetworkMetaTag, error)
 }
 type NetworksAPI struct {
 	DB     NetworkDatabase
@@ -92,5 +94,16 @@ func (a *NetworksAPI) UpdateNetwork(ctx *gin.Context) {
 func (a *NetworksAPI) DeleteNetwork(ctx *gin.Context) {
 	uuid := resolveID(ctx)
 	q, err := a.DB.DeleteNetworkPlugin(uuid)
+	ResponseHandler(q, err, ctx)
+}
+
+func (a *NetworksAPI) CreateNetworkMetaTags(ctx *gin.Context) {
+	networkUUID := resolveID(ctx)
+	body, _ := getBodyBulkNetworkMetaTags(ctx)
+	q, err := a.DB.CreateNetworkMetaTags(networkUUID, body)
+	if err != nil {
+		ResponseHandler(q, err, ctx)
+		return
+	}
 	ResponseHandler(q, err, ctx)
 }

--- a/api/points.go
+++ b/api/points.go
@@ -22,6 +22,8 @@ type PointDatabase interface {
 	UpdatePointPlugin(uuid string, body *model.Point) (*model.Point, error)
 	WritePointPlugin(uuid string, body *model.PointWriter) (*model.Point, error)
 	DeletePointPlugin(uuid string) (bool, error)
+
+	CreatePointMetaTags(pointUUID string, pointMetaTags []*model.PointMetaTag) ([]*model.PointMetaTag, error)
 }
 type PointAPI struct {
 	DB PointDatabase
@@ -116,4 +118,15 @@ func networkDevicePointNames(ctx *gin.Context) (networkName, deviceName, pointNa
 	deviceName = ctx.DefaultQuery(aType.DeviceName, aDefault.DeviceName)
 	pointName = ctx.DefaultQuery(aType.PointName, aDefault.PointName)
 	return networkName, deviceName, pointName
+}
+
+func (a *PointAPI) CreatePointMetaTags(ctx *gin.Context) {
+	pointUUID := resolveID(ctx)
+	body, _ := getBodyBulkPointMetaTag(ctx)
+	q, err := a.DB.CreatePointMetaTags(pointUUID, body)
+	if err != nil {
+		ResponseHandler(q, err, ctx)
+		return
+	}
+	ResponseHandler(q, err, ctx)
 }

--- a/database/devicemetatag.go
+++ b/database/devicemetatag.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"github.com/NubeIO/flow-framework/utils/nuuid"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	"gorm.io/gorm/clause"
+	"strings"
+)
+
+func (d *GormDatabase) CreateDeviceMetaTags(deviceUUID string, body []*model.DeviceMetaTag) ([]*model.DeviceMetaTag,
+	error) {
+	tx := d.DB.Begin()
+	var deviceUUIDs []string
+	for _, b := range body {
+		var count int64
+		tx.Model(&model.DeviceMetaTag{}).Where("device_uuid = ?", deviceUUID).Where("uuid = ?", b.UUID).
+			Count(&count)
+		if count == 0 {
+			b.UUID = nuuid.MakeTopicUUID(model.CommonNaming.DeviceMetaTag)
+		} else {
+			deviceUUIDs = append(deviceUUIDs, b.UUID)
+		}
+		b.DeviceUUID = deviceUUID
+	}
+	notIn := strings.Join(deviceUUIDs, ",")
+	if err := tx.Where("device_uuid = ?", deviceUUID).Where("uuid not in (?)", notIn).
+		Delete(&model.DeviceMetaTag{}).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	if len(body) > 0 {
+		if err := tx.Clauses(clause.OnConflict{UpdateAll: true}).Create(body).Error; err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+	}
+	tx.Commit()
+	return body, nil
+}

--- a/database/networkmetatag.go
+++ b/database/networkmetatag.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"github.com/NubeIO/flow-framework/utils/nuuid"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	"gorm.io/gorm/clause"
+	"strings"
+)
+
+func (d *GormDatabase) CreateNetworkMetaTags(networkUUID string, body []*model.NetworkMetaTag) ([]*model.NetworkMetaTag,
+	error) {
+	tx := d.DB.Begin()
+	var networkUUIDs []string
+	for _, b := range body {
+		var count int64
+		tx.Model(&model.NetworkMetaTag{}).Where("network_uuid = ?", networkUUID).Where("uuid = ?",
+			b.UUID).Count(&count)
+		if count == 0 {
+			b.UUID = nuuid.MakeTopicUUID(model.CommonNaming.NetworkMetaTag)
+		} else {
+			networkUUIDs = append(networkUUIDs, b.UUID)
+		}
+		b.NetworkUUID = networkUUID
+	}
+	notIn := strings.Join(networkUUIDs, ",")
+	if err := tx.Where("network_uuid = ?", networkUUID).Where("uuid not in (?)", notIn).
+		Delete(&model.NetworkMetaTag{}).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	if len(body) > 0 {
+		if err := tx.Clauses(clause.OnConflict{UpdateAll: true}).Create(body).Error; err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+	}
+	tx.Commit()
+	return body, nil
+}

--- a/database/pointmetatag.go
+++ b/database/pointmetatag.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"github.com/NubeIO/flow-framework/utils/nuuid"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	"gorm.io/gorm/clause"
+	"strings"
+)
+
+func (d *GormDatabase) CreatePointMetaTags(pointUUID string, body []*model.PointMetaTag) ([]*model.PointMetaTag,
+	error) {
+	tx := d.DB.Begin()
+	var pointUUIDs []string
+	for _, b := range body {
+		var count int64
+		tx.Model(&model.PointMetaTag{}).Where("point_uuid = ?", pointUUID).Where("uuid = ?", b.UUID).
+			Count(&count)
+		if count == 0 {
+			b.UUID = nuuid.MakeTopicUUID(model.CommonNaming.PointMetaTag)
+		} else {
+			pointUUIDs = append(pointUUIDs, b.UUID)
+		}
+		b.PointUUID = pointUUID
+	}
+	notIn := strings.Join(pointUUIDs, ",")
+	if err := tx.Where("point_uuid = ?", pointUUID).Where("uuid not in (?)", notIn).
+		Delete(&model.PointMetaTag{}).Error; err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+	if len(body) > 0 {
+		if err := tx.Clauses(clause.OnConflict{UpdateAll: true}).Create(body).Error; err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+	}
+	tx.Commit()
+	return body, nil
+}

--- a/database/query_builder.go
+++ b/database/query_builder.go
@@ -188,6 +188,9 @@ func (d *GormDatabase) buildNetworkQuery(args api.Args) *gorm.DB {
 	if args.WithTags {
 		query = query.Preload("Tags")
 	}
+	if args.WithMetaTags {
+		query = query.Preload("MetaTags")
+	}
 	return query
 }
 
@@ -210,6 +213,9 @@ func (d *GormDatabase) buildDeviceQuery(args api.Args) *gorm.DB {
 	}
 	if args.NetworkUUID != nil {
 		query = query.Where("network_uuid = ?", args.NetworkUUID)
+	}
+	if args.WithMetaTags {
+		query = query.Preload("MetaTags")
 	}
 	return query
 }
@@ -236,6 +242,9 @@ func (d *GormDatabase) buildPointQuery(args api.Args) *gorm.DB {
 	}
 	if args.DeviceUUID != nil {
 		query = query.Where("device_uuid = ?", *args.DeviceUUID)
+	}
+	if args.WithMetaTags {
+		query = query.Preload("MetaTags")
 	}
 	return query
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/NubeDev/location v0.0.2
 	github.com/NubeIO/configor v0.0.3
 	github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.7
-	github.com/NubeIO/nubeio-rubix-lib-models-go v1.4.2
+	github.com/NubeIO/nubeio-rubix-lib-models-go v1.4.3
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/gin-contrib/cors v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.7/go.mod h1:oLI6n9wuko0KIEzrL
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.0.4/go.mod h1:A1BPuc3UpE1EF3ugdf+8QIIKTT8s3eK+pfUcheJX2JM=
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.4.2 h1:Hheb/kohlAuvB4wwzNDtTWA9kuwcYVVJTEJ/rZtV7bI=
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.4.2/go.mod h1:J0Xy/dX/f/xIhEnW6ZhkE2LiyuRk2H9gCb0Uk+2SSSk=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.4.3 h1:wYwFxbMs/WfUP1GIju9fWOEN1EuQDUREm4RfUmWgy6c=
+github.com/NubeIO/nubeio-rubix-lib-models-go v1.4.3/go.mod h1:J0Xy/dX/f/xIhEnW6ZhkE2LiyuRk2H9gCb0Uk+2SSSk=
 github.com/NubeIO/nubeio-rubix-lib-rest-go v1.0.6 h1:vQRoKT3vVv+cbI2Sb1Djfgc7etZ93nxmFa83J35C4zA=
 github.com/NubeIO/nubeio-rubix-lib-rest-go v1.0.6/go.mod h1:lRsVVVKF9T3b2l5tL39jpeF6NaqLELYuM4qiof9MShc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/migration/versions/init_schema.go
+++ b/migration/versions/init_schema.go
@@ -31,5 +31,8 @@ func GetInitInterfaces() []interface{} {
 		&model.History{},
 		&model.HistoryLog{},
 		&model.HistoryPostgresLog{},
+		&model.NetworkMetaTag{},
+		&model.DeviceMetaTag{},
+		&model.PointMetaTag{},
 	}
 }

--- a/router/router.go
+++ b/router/router.go
@@ -318,6 +318,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			networkRoutes.GET("/name/:name", networkHandler.GetNetworkByName)
 			networkRoutes.PATCH("/:uuid", networkHandler.UpdateNetwork)
 			networkRoutes.DELETE("/:uuid", networkHandler.DeleteNetwork)
+			networkRoutes.POST("/meta_tags/uuid/:uuid", networkHandler.CreateNetworkMetaTags)
 		}
 
 		deviceRoutes := apiRoutes.Group("/devices")
@@ -329,6 +330,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			deviceRoutes.GET("/name/:network_name/:device_name", deviceHandler.GetDeviceByName)
 			deviceRoutes.PATCH("/:uuid", deviceHandler.UpdateDevice)
 			deviceRoutes.DELETE("/:uuid", deviceHandler.DeleteDevice)
+			deviceRoutes.POST("/meta_tags/uuid/:uuid", deviceHandler.CreateDeviceMetaTags)
 		}
 
 		pointRoutes := apiRoutes.Group("/points")
@@ -345,6 +347,7 @@ func Create(db *database.GormDatabase, conf *config.Configuration) *gin.Engine {
 			pointRoutes.DELETE("/:uuid", pointHandler.DeletePoint)
 			pointRoutes.PATCH("/name", pointHandler.PointWriteByNameArgs) // TODO remove
 			pointRoutes.PATCH("/name/:network_name/:device_name/:point_name", pointHandler.PointWriteByName)
+			pointRoutes.POST("/meta_tags/uuid/:uuid", pointHandler.CreatePointMetaTags)
 		}
 
 		commandRoutes := apiRoutes.Group("/commands")

--- a/utils/nuuid/nuuid.go
+++ b/utils/nuuid/nuuid.go
@@ -38,6 +38,9 @@ func MakeTopicUUID(attribute string) string {
 	rub := "rbx" // rubix uuid
 	rxg := "rxg" // rubix global uuid
 	tok := "tok" // token uuid
+	nmt := "nmt" // network meta tag
+	dmt := "dmt" // device meta tag
+	pmt := "pmt" // point meta tag
 
 	switch attribute {
 	case model.CommonNaming.Plugin:
@@ -84,6 +87,12 @@ func MakeTopicUUID(attribute string) string {
 		return fmt.Sprintf("%s%s%s", rxg, divider, u)
 	case model.CommonNaming.Token:
 		return fmt.Sprintf("%s%s%s", tok, divider, u)
+	case model.CommonNaming.NetworkMetaTag:
+		return fmt.Sprintf("%s%s%s", nmt, divider, u)
+	case model.CommonNaming.DeviceMetaTag:
+		return fmt.Sprintf("%s%s%s", dmt, divider, u)
+	case model.CommonNaming.PointMetaTag:
+		return fmt.Sprintf("%s%s%s", pmt, divider, u)
 	}
 	return u
 }


### PR DESCRIPTION
Resolves: #676 

### Summary
- Added meta tags API endpoints for network, device and point
- POST `api/networks/meta_tags/uuid/<network_uuid>` 
- POST `api/devices/meta_tags/uuid/<device_uuid>`
- POST `api/points/meta_tags/uuid/<network_uuid>`
   ```
    -d [
          {
            "key": <key>,
            "value": <value>
         },
          {
            "uuid":<uuid>,
            "key": <key>,
            "value": <value>
         },
      ]
  ```
- Added `with_meta_tags` param in `api/networks?with_meta_tags=true`, `api/devices?with_meta_tags=true` and `api/points?with_meta_tags=true`