### PR TITLE
Feature/query history with meta tags

### DIFF
--- a/plugin/nube/database/postgres/README.md
+++ b/plugin/nube/database/postgres/README.md
@@ -34,12 +34,17 @@
         - `device_id`
         - `device_name`
         - `tag`     
+        - `meta_tag_key`
+        - `meta_tag_value`
     - Filter examples:   
         ```
         1. rubix_network_name={network_name}&&rubix_device_name={device_name}&&rubix_point_name={point_name}&&site_id={site_id}
         2. (site_name={site_name}&&timestamp>{timestamp})||rubix_point_uuid!={point_uuid}
         3. (tag={tag}&&value>={value})||(tag={tag}&&value<={value})
-        4. rubix_point_uuid=<{oint_uuid}||rubix_point_uuid={point_uuid}
+        4. rubix_point_uuid=<{point_uuid}||rubix_point_uuid={point_uuid}
+        5. (meta_tag_key={meta_tag_key}&&value>={value})
+        6. (meta_tag_value={meta_tag_value}&&value<={value})
+        7. (meta_tag_key={meta_tag_key}&&meta_tag_value={meta_tag_value}&&value>={value})
         ```
 - limit
 - offset

--- a/plugin/nube/database/postgres/api.go
+++ b/plugin/nube/database/postgres/api.go
@@ -16,26 +16,35 @@ var (
 	logicalOperators        = []string{"&&", "||"}
 	comparisonOperators     = []string{"=", ">", "<", "<=", ">=", "!="}
 	orderOperators          = []string{"(", ")"}
-	tagColumns              = []string{"tag"}
 	flowNetworkCloneColumns = []string{"global_uuid", "client_id", "client_name", "site_id", "site_name", "device_id",
 		"device_name"}
-	filterMap = map[string]string{
-		"timestamp":          "histories.timestamp",
-		"value":              "histories.value",
-		"rubix_network_uuid": "networks.uuid",
-		"rubix_network_name": "networks.name",
-		"rubix_device_uuid":  "devices.uuid",
-		"rubix_device_name":  "devices.name",
-		"rubix_point_uuid":   "points.uuid",
-		"rubix_point_name":   "points.name",
-		"tag":                "networks_tags.tag_tag,devices_tags.tag_tag,points_tags.tag_tag",
-		"global_uuid":        "flow_network_clones.global_uuid",
-		"client_id":          "flow_network_clones.client_id",
-		"client_name":        "flow_network_clones.client_name",
-		"site_id":            "flow_network_clones.site_id",
-		"site_name":          "flow_network_clones.site_name",
-		"device_id":          "flow_network_clones.device_id",
-		"device_name":        "flow_network_clones.device_name",
+	filterQueryMap = map[string]string{
+		"timestamp":          "histories.timestamp" + operatorFormat + valueFormat,
+		"value":              "histories.value" + operatorFormat + valueFormat,
+		"rubix_network_uuid": "networks.uuid" + operatorFormat + valueFormat,
+		"rubix_network_name": "networks.name" + operatorFormat + valueFormat,
+		"rubix_device_uuid":  "devices.uuid" + operatorFormat + valueFormat,
+		"rubix_device_name":  "devices.name" + operatorFormat + valueFormat,
+		"rubix_point_uuid":   "points.uuid" + operatorFormat + valueFormat,
+		"rubix_point_name":   "points.name" + operatorFormat + valueFormat,
+		"global_uuid":        "flow_network_clones.global_uuid" + operatorFormat + valueFormat,
+		"client_id":          "flow_network_clones.client_id" + operatorFormat + valueFormat,
+		"client_name":        "flow_network_clones.client_name" + operatorFormat + valueFormat,
+		"site_id":            "flow_network_clones.site_id" + operatorFormat + valueFormat,
+		"site_name":          "flow_network_clones.site_name" + operatorFormat + valueFormat,
+		"device_id":          "flow_network_clones.device_id" + operatorFormat + valueFormat,
+		"tag": "(networks.uuid in (SELECT network_uuid FROM networks_tags WHERE tag_tag" +
+			operatorFormat + valueFormat + ") OR devices.uuid in (SELECT device_uuid FROM devices_tags WHERE tag_tag" +
+			operatorFormat + valueFormat + ") OR points.uuid in (SELECT point_uuid FROM points_tags WHERE tag_tag" +
+			operatorFormat + valueFormat + "))",
+		"meta_tag_key": "(networks.uuid in (SELECT network_uuid FROM network_meta_tags WHERE key" +
+			operatorFormat + valueFormat + ") OR devices.uuid in (SELECT device_uuid FROM device_meta_tags WHERE key" +
+			operatorFormat + valueFormat + ") OR points.uuid in (SELECT point_uuid FROM point_meta_tags WHERE key" +
+			operatorFormat + valueFormat + "))",
+		"meta_tag_value": "(networks.uuid in (SELECT network_uuid FROM network_meta_tags WHERE value" +
+			operatorFormat + valueFormat + ") OR devices.uuid in (SELECT device_uuid FROM device_meta_tags WHERE value" +
+			operatorFormat + valueFormat + ") OR points.uuid in (SELECT point_uuid FROM point_meta_tags WHERE value" +
+			operatorFormat + valueFormat + "))",
 	}
 )
 

--- a/plugin/nube/database/postgres/pgmodel/model.go
+++ b/plugin/nube/database/postgres/pgmodel/model.go
@@ -161,14 +161,7 @@ type HistoryData struct {
 	RubixDeviceName  string    `json:"rubix_device_name"`
 	RubixPointUUID   string    `json:"rubix_point_uuid"`
 	RubixPointName   string    `json:"rubix_point_name"`
-	TagData
 	FlowNetworkCloneData
-}
-
-type TagData struct {
-	NetworkTag string `json:"network_tag,omitempty"`
-	DeviceTag  string `json:"device_tag,omitempty"`
-	PointTag   string `json:"point_tag,omitempty"`
 }
 
 type FlowNetworkCloneData struct {

--- a/plugin/nube/database/postgres/postgres.go
+++ b/plugin/nube/database/postgres/postgres.go
@@ -108,11 +108,11 @@ func (ps PostgresSetting) GetHistories(args Args) ([]*pgmodel.HistoryData, error
 }
 
 func (ps PostgresSetting) buildHistoryQuery(args Args) (*gorm.DB, error) {
-	filterQuery, hasTag, hasFnc, err := buildFilterQuery(args.Filter)
+	filterQuery, hasFnc, err := buildFilterQuery(args.Filter)
 	if err != nil {
 		return nil, err
 	}
-	selectQuery := buildSelectQuery(hasTag, hasFnc)
+	selectQuery := buildSelectQuery(hasFnc)
 	query := ps.postgresConnectionInstance.db
 	query = query.Table("histories").
 		Select(selectQuery).
@@ -121,11 +121,6 @@ func (ps PostgresSetting) buildHistoryQuery(args Args) (*gorm.DB, error) {
 		Joins("INNER JOIN points ON points.uuid = writers.writer_thing_uuid").
 		Joins("INNER JOIN devices ON devices.uuid = points.device_uuid").
 		Joins("INNER JOIN networks ON networks.uuid = devices.network_uuid")
-	if hasTag {
-		query = query.Joins("LEFT JOIN points_tags ON points_tags.point_uuid = points.uuid").
-			Joins("LEFT JOIN devices_tags ON devices_tags.device_uuid = devices.uuid").
-			Joins("LEFT JOIN networks_tags ON networks_tags.network_uuid = networks.uuid")
-	}
 	if hasFnc {
 		query = query.Joins("INNER JOIN stream_clones ON stream_clones.uuid = consumers.stream_clone_uuid").
 			Joins("INNER JOIN flow_network_clones ON flow_network_clones.uuid = stream_clones.flow_network_clone_uuid")

--- a/plugin/nube/database/postgres/postgres.go
+++ b/plugin/nube/database/postgres/postgres.go
@@ -147,12 +147,16 @@ func (ps PostgresSetting) buildHistoryQuery(args Args) (*gorm.DB, error) {
 			query.Offset(offset)
 		}
 	}
-	if args.OrderBy != nil {
+	if args.OrderBy != nil || args.Order != nil {
 		order := "DESC"
+		orderBy := "timestamp"
 		if args.Order != nil && strings.ToUpper(strings.TrimSpace(*args.Order)) == "ASC" {
 			order = "ASC"
 		}
-		query.Order(fmt.Sprintf("%s %s", *args.OrderBy, order))
+		if args.OrderBy != nil {
+			orderBy = *args.OrderBy
+		}
+		query.Order(fmt.Sprintf("%s %s", orderBy, order))
 	}
 	return query, nil
 }

--- a/plugin/nube/database/postgres/utils.go
+++ b/plugin/nube/database/postgres/utils.go
@@ -8,15 +8,10 @@ import (
 	"strings"
 )
 
-func buildSelectQuery(hasTag bool, hasFnc bool) string {
+func buildSelectQuery(hasFnc bool) string {
 	query := "histories.value, histories.timestamp, points.uuid AS rubix_point_uuid, points.name AS rubix_point_name," +
 		" devices.uuid AS rubix_device_uuid, devices.name AS rubix_device_name, networks.uuid AS rubix_network_uuid," +
 		" networks.name AS rubix_network_name"
-	if hasTag {
-		tagQuery := ", networks_tags.tag_tag AS network_tag, devices_tags.tag_tag AS device_tag, " +
-			"points_tags.tag_tag AS point_tag"
-		query += fmt.Sprintf("%s", tagQuery)
-	}
 	if hasFnc {
 		fncQuery := ", flow_network_clones.global_uuid, flow_network_clones.client_id, " +
 			"flow_network_clones.client_name, flow_network_clones.site_id, flow_network_clones.site_name, " +
@@ -26,9 +21,9 @@ func buildSelectQuery(hasTag bool, hasFnc bool) string {
 	return query
 }
 
-func buildFilterQuery(filter *string) (filterQuery string, hasTag bool, hasFnc bool, err error) {
+func buildFilterQuery(filter *string) (filterQuery string, hasFnc bool, err error) {
 	if filter == nil {
-		return "", hasTag, hasFnc, nil
+		return "", hasFnc, nil
 	}
 	isColumn := true
 	re := regexp.MustCompile(filterRegex)
@@ -53,37 +48,24 @@ func buildFilterQuery(filter *string) (filterQuery string, hasTag bool, hasFnc b
 		if isColumn {
 			column, err := getColumn(f)
 			if err != nil {
-				return "", hasTag, hasFnc, err
+				return "", hasFnc, err
 			}
-			filterQuery += column
-			hasTag = hasTag || contains(f, tagColumns)
 			hasFnc = hasFnc || contains(f, flowNetworkCloneColumns)
+			filterQuery += column
 		} else {
 			value := fmt.Sprintf("'%s'", f)
 			filterQuery = strings.Replace(filterQuery, valueFormat, value, -1)
 		}
 		isColumn = !isColumn
 	}
-	return filterQuery, hasTag, hasFnc, err
+	return filterQuery, hasFnc, err
 }
 
 func getColumn(key string) (string, error) {
-	columns := strings.Split(filterMap[key], ",")
-	if columns[0] == "" {
+	if filterQueryMap[key] == "" {
 		return "", errors.New("invalid column")
 	}
-	if len(columns) == 1 {
-		return fmt.Sprintf("%s%s%s", columns[0], operatorFormat, valueFormat), nil
-	}
-	column := "("
-	for i, f := range columns {
-		if i == len(columns)-1 {
-			column += fmt.Sprintf("%s%s%s%s", f, operatorFormat, valueFormat, ")")
-		} else {
-			column += fmt.Sprintf("%s%s%s %s ", f, operatorFormat, valueFormat, "OR")
-		}
-	}
-	return column, nil
+	return filterQueryMap[key], nil
 }
 
 func contains(v string, a []string) bool {


### PR DESCRIPTION
Resolves: #750
### Summary:
- Added `meta_tag_key` and `meta_tag_value` filters. Exmples:
  ```
   1. api/postgres/histories?filter=meta_tag_key=<meta_tag_key>&&meta_tag_value=<meta_tag_value>
  ```
- Made `orderBy` default to `timestamp` if `order` param is provided . Examples
  ```
   1. api/postgres/histories?order_by=rubix_point_name&order=asc  (orderBy default: timestamp)
   2. 
  ```