### PR TITLE
Add flow_https_local,flow_ip_local and flow_port_local

### DIFF
--- a/database/flow_network.go
+++ b/database/flow_network.go
@@ -304,15 +304,16 @@ func (d *GormDatabase) afterCreateUpdateFlowNetwork(body *model.FlowNetwork, isM
 			tx.Rollback()
 			return nil, err
 		}
-		bodyToSync.FlowHTTPS = localStorageFlowNetwork.FlowHTTPS
-		bodyToSync.FlowIP = nstring.NewStringAddress(localStorageFlowNetwork.FlowIP)
 		if boolean.IsTrue(body.IsTokenAuth) {
-			conf := config.Get()
-			body.FlowPort = integer.New(conf.Server.Port)
+			bodyToSync.FlowHTTPS = body.FlowHTTSLocal
+			bodyToSync.FlowIP = body.FlowIPLocal
+			bodyToSync.FlowPort = body.FlowPortLocal
 			bodyToSync.FlowUsername = nil
 			bodyToSync.FlowPassword = nil
 			bodyToSync.FlowToken = body.FlowTokenLocal
 		} else {
+			bodyToSync.FlowHTTPS = localStorageFlowNetwork.FlowHTTPS
+			bodyToSync.FlowIP = nstring.NewStringAddress(localStorageFlowNetwork.FlowIP)
 			bodyToSync.FlowPort = integer.New(localStorageFlowNetwork.FlowPort)
 			bodyToSync.FlowUsername = nstring.NewStringAddress(localStorageFlowNetwork.FlowUsername)
 			bodyToSync.FlowPassword = nstring.NewStringAddress(localStorageFlowNetwork.FlowPassword)


### PR DESCRIPTION
Resolves: #809 
### Summary:
- Added `flow_https_local`,`flow_ip_local` and `flow_port_local` while creating flow_network
```
   {
    "name": "flow network (178)",
    "flow_https": false,
    "flow_ip": "10.8.1.9",
    "flow_port": 1660,
    "is_remote": true,
    "is_token_auth": true,
    "flow_token_local": "$2a$10$3XzaT.nToFae8FW9mi7zfe6kU3.h.jfVYnuBe6LnQEDWyufSIMreC",
    "flow_token": "$2a$10$CcPccG3R1SEptPt.gjfPiOyIihB6r2C77pLx9MZBowPsROLa1Z3..",
    "flow_https_local": false,
    "flow_ip_local": "0.0.0.0",
    "flow_port_local": 1616
   }
```