### PR TITLE
Add meta tags query param on network, device and point

### DIFF
--- a/api/args.go
+++ b/api/args.go
@@ -67,6 +67,7 @@ type Args struct {
 	WithMetaTags         bool
 	AutoMappingUUID      *string
 	AutoMappingEnable    *bool
+	MetaTags             *string
 }
 
 var ArgsType = struct {
@@ -136,6 +137,7 @@ var ArgsType = struct {
 	WithMetaTags         string
 	AutoMappingUUID      string
 	AutoMappingEnable    string
+	MetaTags             string
 }{
 	Sort:                 "sort",
 	Order:                "order",
@@ -203,6 +205,7 @@ var ArgsType = struct {
 	WithMetaTags:         "with_meta_tags",
 	AutoMappingUUID:      "auto_mapping_uuid",
 	AutoMappingEnable:    "auto_mapping_enable",
+	MetaTags:             "meta_tags",
 }
 
 var ArgsDefault = struct {
@@ -250,6 +253,7 @@ var ArgsDefault = struct {
 	WithMetaTags      string
 	AutoMappingUUID   string
 	AutoMappingEnable string
+	MetaTags          string
 }{
 	Sort:              "ID",
 	Order:             "DESC", // ASC or DESC
@@ -294,4 +298,5 @@ var ArgsDefault = struct {
 	WithMetaTags:      "false",
 	AutoMappingUUID:   "",
 	AutoMappingEnable: "false",
+	MetaTags:          "",
 }

--- a/api/args_builder.go
+++ b/api/args_builder.go
@@ -139,6 +139,9 @@ func buildNetworkArgs(ctx *gin.Context) Args {
 	if value, ok := ctx.GetQuery(aType.AutoMappingUUID); ok {
 		args.AutoMappingUUID = &value
 	}
+	if value, ok := ctx.GetQuery(aType.MetaTags); ok {
+		args.MetaTags = &value
+	}
 	return args
 }
 
@@ -155,6 +158,9 @@ func buildDeviceArgs(ctx *gin.Context) Args {
 	}
 	if value, ok := ctx.GetQuery(aType.AutoMappingUUID); ok {
 		args.AutoMappingUUID = &value
+	}
+	if value, ok := ctx.GetQuery(aType.MetaTags); ok {
+		args.MetaTags = &value
 	}
 	return args
 }
@@ -177,6 +183,9 @@ func buildPointArgs(ctx *gin.Context) Args {
 	}
 	if value, ok := ctx.GetQuery(aType.ObjectType); ok {
 		args.ObjectType = &value
+	}
+	if value, ok := ctx.GetQuery(aType.MetaTags); ok {
+		args.MetaTags = &value
 	}
 	return args
 }

--- a/database/query_builder.go
+++ b/database/query_builder.go
@@ -206,6 +206,14 @@ func (d *GormDatabase) buildNetworkQuery(args api.Args) *gorm.DB {
 	if args.AutoMappingUUID != nil {
 		query = query.Where("auto_mapping_uuid = ?", args.AutoMappingUUID)
 	}
+	if args.MetaTags != nil {
+		keyValues := metaTagsArgsToKeyValues(*args.MetaTags)
+		subQuery := d.DB.Table("network_meta_tags").Select("network_uuid").
+			Where("(key, value) IN ?", keyValues).
+			Group("network_uuid").
+			Having("COUNT(network_uuid) = ?", len(keyValues))
+		query = query.Where("uuid IN (?)", subQuery)
+	}
 	return query
 }
 
@@ -238,6 +246,14 @@ func (d *GormDatabase) buildDeviceQuery(args api.Args) *gorm.DB {
 	if args.WithMetaTags {
 		query = query.Preload("MetaTags")
 	}
+	if args.MetaTags != nil {
+		keyValues := metaTagsArgsToKeyValues(*args.MetaTags)
+		subQuery := d.DB.Table("device_meta_tags").Select("device_uuid").
+			Where("(key, value) IN ?", keyValues).
+			Group("device_uuid").
+			Having("COUNT(device_uuid) = ?", len(keyValues))
+		query = query.Where("uuid IN (?)", subQuery)
+	}
 	return query
 }
 
@@ -269,6 +285,14 @@ func (d *GormDatabase) buildPointQuery(args api.Args) *gorm.DB {
 	}
 	if args.WithMetaTags {
 		query = query.Preload("MetaTags")
+	}
+	if args.MetaTags != nil {
+		keyValues := metaTagsArgsToKeyValues(*args.MetaTags)
+		subQuery := d.DB.Table("point_meta_tags").Select("point_uuid").
+			Where("(key, value) IN ?", keyValues).
+			Group("point_uuid").
+			Having("COUNT(point_uuid) = ?", len(keyValues))
+		query = query.Where("uuid IN (?)", subQuery)
 	}
 	return query
 }

--- a/database/utils.go
+++ b/database/utils.go
@@ -1,13 +1,13 @@
 package database
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/NubeIO/flow-framework/utils/nuuid"
 	"github.com/NubeIO/flow-framework/utils/structs"
-	"gorm.io/gorm"
-
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	"gorm.io/gorm"
 )
 
 func truncateString(str string, num int) string {
@@ -97,4 +97,17 @@ func (d *GormDatabase) deleteResponseBuilder(query *gorm.DB) (bool, error) {
 	} else {
 		return true, nil
 	}
+}
+
+func metaTagsArgsToKeyValues(metaTags string) [][]interface{} {
+	mapMetaTags := map[string]string{}
+	var keyValues [][]interface{}
+	_ = json.Unmarshal([]byte(metaTags), &mapMetaTags)
+	for k, v := range mapMetaTags {
+		keyValues = append(keyValues, []interface{}{k, v})
+	}
+	if keyValues == nil {
+		keyValues = append(keyValues, []interface{}{"", ""})
+	}
+	return keyValues
 }


### PR DESCRIPTION
Resolves: #816
### Summary:
- Added `meta_tags` query param on network, device and point. Examples:
   - api/networks?meta_tags={"key": "value","key":value",.....}
   - api/devices?meta_tags={"key": "value","key":value",.....}
   - api/points?meta_tags={"key": "value","key":value",.....}