### PR TITLE
Release/0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v0.12.1](https://github.com/NubeIO/flow-framework/tree/v0.12.1) (2023-04-04)
+
+- Remove point update buffer as it's using ~2x CPU power
+  - It also fixes the slow MQTT publish issue
+- Improvement to run auto-mapping for all different fns
+
 ## [v0.12.0](https://github.com/NubeIO/flow-framework/tree/v0.12.0) (2023-04-02)
 
 - Auto mapping improvements

--- a/database/network.go
+++ b/database/network.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NubeIO/flow-framework/utils/deviceinfo"
 	"github.com/NubeIO/flow-framework/utils/nuuid"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 	"strings"
 )
@@ -175,6 +176,7 @@ func (d *GormDatabase) SyncNetworks(args api.Args) error {
 	args.WithTags = true
 	args.WithMetaTags = true
 	networks, err := d.GetNetworks(args)
+	var firstErr error
 	if err != nil {
 		return err
 	}
@@ -182,10 +184,10 @@ func (d *GormDatabase) SyncNetworks(args api.Args) error {
 	for _, fnName := range uniqueAutoMappingFlowNetworkNames {
 		err = d.CreateNetworksAutoMappings(fnName, networks, interfaces.Network)
 		if err != nil {
-			return err
+			log.Error("Auto mapping error: ", err)
 		}
 	}
-	return nil
+	return firstErr
 }
 
 func (d *GormDatabase) SyncNetworkDevices(uuid string, args api.Args) error {


### PR DESCRIPTION
### Summary

- Remove point update buffer as it's using ~2x CPU power
  - It also fixes the slow MQTT publish issue
- Improvement to run auto-mapping for all different fns